### PR TITLE
Return semantic tokens for non-Python code for syntax highlighting

### DIFF
--- a/src/xonsh_lsp/parser.py
+++ b/src/xonsh_lsp/parser.py
@@ -38,84 +38,53 @@ except ImportError:
 logger = logging.getLogger(__name__)
 
 
-# ---------------------------------------------------------------------------
-# Semantic token indices — must match SEMANTIC_TOKENS_LEGEND in server.py
-# ---------------------------------------------------------------------------
+# Tree-sitter highlights.scm capture → LSP semantic token, ordered by descending
+# priority. When multiple captures match the same node, the first listed wins.
+# Indices must match SEMANTIC_TOKENS_LEGEND in server.py (both derive from
+# lsprotocol's enum order).
 _TYPE_INDEX: dict[str, int] = {t.value: i for i, t in enumerate(lsp.SemanticTokenTypes)}
 _MOD_INDEX: dict[str, int] = {m.value: i for i, m in enumerate(lsp.SemanticTokenModifiers)}
 
 
 def _mod_bits(*names: str) -> int:
-    return sum(1 << _MOD_INDEX[n] for n in names if n in _MOD_INDEX)
+    return sum(1 << _MOD_INDEX[n] for n in names)
 
 
-# capture_name → (type_index, modifier_bits)
-_CAPTURE_TOKEN: dict[str, tuple[int, int]] = {
-    k: (_TYPE_INDEX[t], _mod_bits(*mods))
-    for k, t, mods in [
-        ("comment",                "comment",   []),
-        ("string",                 "string",    []),
-        ("string.escape",          "string",    []),
-        ("string.special",         "string",    []),
-        ("string.special.path",    "string",    []),
-        ("string.special.symbol",  "string",    []),
-        ("string.regexp",          "regexp",    []),
-        ("number",                 "number",    []),
-        ("number.float",           "number",    []),
-        ("keyword",                "keyword",   []),
-        ("keyword.import",         "keyword",   []),
-        ("keyword.exception",      "keyword",   []),
-        ("keyword.operator",       "keyword",   []),
-        ("operator",               "operator",  []),
-        ("variable",               "variable",  []),
-        ("variable.builtin",       "variable",  ["defaultLibrary"]),
-        ("variable.parameter",     "parameter", []),
-        ("function",               "function",  []),
-        ("function.call",          "function",  []),
-        ("function.builtin",       "function",  ["defaultLibrary"]),
-        ("function.method.call",   "method",    []),
-        ("type",                   "type",      []),
-        ("module",                 "namespace", []),
-        ("property",               "property",  []),
-        ("attribute",              "decorator", []),
-        ("boolean",                "keyword",   ["readonly"]),
-        ("constant.builtin",       "variable",  ["readonly", "defaultLibrary"]),
-    ]
+_CAPTURES_ORDERED: list[tuple[str, str, tuple[str, ...]]] = [
+    ("function.builtin",      "function",  ("defaultLibrary",)),
+    ("function.method.call",  "method",    ()),
+    ("variable.parameter",    "parameter", ()),  # flags (^-) beat function.call
+    ("function.call",         "function",  ()),
+    ("function",              "function",  ()),
+    ("type",                  "type",      ()),
+    ("module",                "namespace", ()),
+    ("property",              "property",  ()),
+    ("variable.builtin",      "variable",  ("defaultLibrary",)),
+    ("constant.builtin",      "variable",  ("readonly", "defaultLibrary")),
+    ("boolean",               "keyword",   ("readonly",)),
+    ("keyword.exception",     "keyword",   ()),
+    ("keyword.import",        "keyword",   ()),
+    ("keyword.operator",      "keyword",   ()),
+    ("keyword",               "keyword",   ()),
+    ("operator",              "operator",  ()),
+    ("string.regexp",         "regexp",    ()),
+    ("string.special.path",   "string",    ()),
+    ("string.special.symbol", "string",    ()),
+    ("string.special",        "string",    ()),
+    ("string.escape",         "string",    ()),
+    ("string",                "string",    ()),
+    ("number.float",          "number",    ()),
+    ("number",                "number",    ()),
+    ("comment",               "comment",   ()),
+    ("attribute",             "decorator", ()),
+    ("variable",              "variable",  ()),
+]
+
+# capture_name → (priority, type_index, modifier_bits)
+_CAPTURE_INFO: dict[str, tuple[int, int, int]] = {
+    name: (i, _TYPE_INDEX[t], _mod_bits(*mods))
+    for i, (name, t, mods) in enumerate(_CAPTURES_ORDERED)
     if t in _TYPE_INDEX
-}
-
-# When multiple captures match the same node, lower index wins
-_CAPTURE_PRIORITY: dict[str, int] = {
-    name: i for i, name in enumerate([
-        "function.builtin",
-        "function.method.call",
-        "variable.parameter",   # flags (^-) beat generic function.call
-        "function.call",
-        "function",
-        "type",
-        "module",
-        "property",
-        "variable.builtin",
-        "constant.builtin",
-        "boolean",
-        "keyword.exception",
-        "keyword.import",
-        "keyword.operator",
-        "keyword",
-        "operator",
-        "string.regexp",
-        "string.special.path",
-        "string.special.symbol",
-        "string.special",
-        "string.escape",
-        "string",
-        "number.float",
-        "number",
-        "comment",
-        "attribute",
-        "decorator",
-        "variable",
-    ])
 }
 
 
@@ -250,45 +219,42 @@ class XonshParser:
             cursor.set_point_range((start_line, 0), (end_line + 1, 0))
         captures: dict[str, list[Node]] = cursor.captures(result.tree.root_node)
 
-        # Group relevant capture names by (start_byte, end_byte)
-        range_captures: dict[tuple[int, int], list[str]] = {}
-        range_node: dict[tuple[int, int], Node] = {}
+        # For each node range, keep the highest-priority capture only.
+        best_per_range: dict[tuple[int, int], tuple[int, Node, int, int]] = {}
         for capture_name, nodes in captures.items():
-            if capture_name not in _CAPTURE_PRIORITY:
+            info = _CAPTURE_INFO.get(capture_name)
+            if info is None:
                 continue
+            priority, type_idx, mod_bits = info
             for node in nodes:
                 key = (node.start_byte, node.end_byte)
-                range_captures.setdefault(key, []).append(capture_name)
-                range_node.setdefault(key, node)
+                existing = best_per_range.get(key)
+                if existing is None or priority < existing[0]:
+                    best_per_range[key] = (priority, node, type_idx, mod_bits)
 
-        # Build sorted token list
-        raw: list[tuple[int, int, int, int, int]] = []
-        for key, names in range_captures.items():
-            best: str = min(names, key=lambda n: _CAPTURE_PRIORITY.get(n, 999))
-            type_idx, mod_bits = _CAPTURE_TOKEN[best]
-            node = range_node[key]
+        tokens: list[tuple[int, int, int, int, int]] = []
+        for _, node, type_idx, mod_bits in best_per_range.values():
             row, col = node.start_point
             end_row, end_col = node.end_point
             if row != end_row:
-                continue  # skip multi-line nodes
+                continue
             length = end_col - col
             if length <= 0:
                 continue
-            raw.append((row, col, length, type_idx, mod_bits))
+            tokens.append((row, col, length, type_idx, mod_bits))
 
-        raw.sort(key=lambda t: (t[0], t[1]))
+        tokens.sort(key=lambda t: (t[0], t[1]))
 
-        # Remove tokens whose range is contained within the previous token
-        # (e.g. string_content inside string — keep the outer one)
+        # Drop tokens nested inside the previous one (e.g. string_content inside
+        # string — highlights.scm captures both, but we want a single outer span).
         deduped: list[tuple[int, int, int, int, int]] = []
-        for tok in raw:
+        for tok in tokens:
             if deduped:
                 prev = deduped[-1]
                 if tok[0] == prev[0] and tok[1] < prev[1] + prev[2]:
                     continue
             deduped.append(tok)
 
-        # Delta-encode
         data: list[int] = []
         prev_line = prev_col = 0
         for line, col, length, type_idx, mod_bits in deduped:

--- a/src/xonsh_lsp/parser.py
+++ b/src/xonsh_lsp/parser.py
@@ -201,23 +201,19 @@ class XonshParser:
 
     def get_semantic_tokens(
         self,
-        source: str,
-        start_line: int | None = None,
-        end_line: int | None = None,
+        parse_result: ParseResult | None,
+        range: lsp.Range | None = None,
     ) -> lsp.SemanticTokens | None:
-        if not self._initialized:
+        if not self._initialized or parse_result is None or parse_result.tree is None:
             return None
-        result = self.parse(source)
-        if result.tree is None:
-            return None
+
         query = self._get_highlights_query()
         if query is None:
             return None
-
         cursor = QueryCursor(query)
-        if start_line is not None and end_line is not None:
-            cursor.set_point_range((start_line, 0), (end_line + 1, 0))
-        captures: dict[str, list[Node]] = cursor.captures(result.tree.root_node)
+        if range is not None:
+            cursor.set_point_range((range.start.line, 0), (range.end.line + 1, 0))
+        captures: dict[str, list[Node]] = cursor.captures(parse_result.tree.root_node)
 
         # For each node range, keep the highest-priority capture only.
         best_per_range: dict[tuple[int, int], tuple[int, Node, int, int]] = {}

--- a/src/xonsh_lsp/parser.py
+++ b/src/xonsh_lsp/parser.py
@@ -8,11 +8,14 @@ Falls back to basic parsing if xonsh grammar is not available.
 from __future__ import annotations
 
 import logging
+import pathlib
 from dataclasses import dataclass
 from typing import Iterator
 
+from lsprotocol import types as lsp
+
 try:
-    from tree_sitter import Language, Parser, Node, Tree
+    from tree_sitter import Language, Parser, Node, Tree, Query, QueryCursor
 
     TREE_SITTER_AVAILABLE = True
 except ImportError:
@@ -21,6 +24,8 @@ except ImportError:
     Tree = object  # type: ignore
     Language = object  # type: ignore
     Parser = object  # type: ignore
+    Query = object  # type: ignore
+    QueryCursor = object  # type: ignore
 
 try:
     import tree_sitter_xonsh
@@ -31,6 +36,87 @@ except ImportError:
     tree_sitter_xonsh = None  # type: ignore
 
 logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Semantic token indices — must match SEMANTIC_TOKENS_LEGEND in server.py
+# ---------------------------------------------------------------------------
+_TYPE_INDEX: dict[str, int] = {t.value: i for i, t in enumerate(lsp.SemanticTokenTypes)}
+_MOD_INDEX: dict[str, int] = {m.value: i for i, m in enumerate(lsp.SemanticTokenModifiers)}
+
+
+def _mod_bits(*names: str) -> int:
+    return sum(1 << _MOD_INDEX[n] for n in names if n in _MOD_INDEX)
+
+
+# capture_name → (type_index, modifier_bits)
+_CAPTURE_TOKEN: dict[str, tuple[int, int]] = {
+    k: (_TYPE_INDEX[t], _mod_bits(*mods))
+    for k, t, mods in [
+        ("comment",                "comment",   []),
+        ("string",                 "string",    []),
+        ("string.escape",          "string",    []),
+        ("string.special",         "string",    []),
+        ("string.special.path",    "string",    []),
+        ("string.special.symbol",  "string",    []),
+        ("string.regexp",          "regexp",    []),
+        ("number",                 "number",    []),
+        ("number.float",           "number",    []),
+        ("keyword",                "keyword",   []),
+        ("keyword.import",         "keyword",   []),
+        ("keyword.exception",      "keyword",   []),
+        ("keyword.operator",       "keyword",   []),
+        ("operator",               "operator",  []),
+        ("variable",               "variable",  []),
+        ("variable.builtin",       "variable",  ["defaultLibrary"]),
+        ("variable.parameter",     "parameter", []),
+        ("function",               "function",  []),
+        ("function.call",          "function",  []),
+        ("function.builtin",       "function",  ["defaultLibrary"]),
+        ("function.method.call",   "method",    []),
+        ("type",                   "type",      []),
+        ("module",                 "namespace", []),
+        ("property",               "property",  []),
+        ("attribute",              "decorator", []),
+        ("boolean",                "keyword",   ["readonly"]),
+        ("constant.builtin",       "variable",  ["readonly", "defaultLibrary"]),
+    ]
+    if t in _TYPE_INDEX
+}
+
+# When multiple captures match the same node, lower index wins
+_CAPTURE_PRIORITY: dict[str, int] = {
+    name: i for i, name in enumerate([
+        "function.builtin",
+        "function.method.call",
+        "variable.parameter",   # flags (^-) beat generic function.call
+        "function.call",
+        "function",
+        "type",
+        "module",
+        "property",
+        "variable.builtin",
+        "constant.builtin",
+        "boolean",
+        "keyword.exception",
+        "keyword.import",
+        "keyword.operator",
+        "keyword",
+        "operator",
+        "string.regexp",
+        "string.special.path",
+        "string.special.symbol",
+        "string.special",
+        "string.escape",
+        "string",
+        "number.float",
+        "number",
+        "comment",
+        "attribute",
+        "decorator",
+        "variable",
+    ])
+}
 
 
 @dataclass
@@ -97,6 +183,7 @@ class XonshParser:
         self._parser: Parser | None = None
         self._language: Language | None = None
         self._initialized = False
+        self._highlights_query: Query | None = None
 
         if TREE_SITTER_AVAILABLE:
             self._init_parser()
@@ -126,6 +213,91 @@ class XonshParser:
             logger.error(f"Failed to initialize parser: {e}")
             self._parser = None
             self._language = None
+
+    def _get_highlights_query(self) -> Query | None:
+        if self._highlights_query is not None:
+            return self._highlights_query
+        if self._language is None or not XONSH_GRAMMAR_AVAILABLE:
+            return None
+        try:
+            scm = (
+                pathlib.Path(tree_sitter_xonsh.__file__).parent
+                / "queries"
+                / "highlights.scm"
+            ).read_text()
+            self._highlights_query = Query(self._language, scm)
+        except Exception as e:
+            logger.warning(f"Failed to load highlights query: {e}")
+        return self._highlights_query
+
+    def get_semantic_tokens(
+        self,
+        source: str,
+        start_line: int | None = None,
+        end_line: int | None = None,
+    ) -> lsp.SemanticTokens | None:
+        if not self._initialized:
+            return None
+        result = self.parse(source)
+        if result.tree is None:
+            return None
+        query = self._get_highlights_query()
+        if query is None:
+            return None
+
+        cursor = QueryCursor(query)
+        if start_line is not None and end_line is not None:
+            cursor.set_point_range((start_line, 0), (end_line + 1, 0))
+        captures: dict[str, list[Node]] = cursor.captures(result.tree.root_node)
+
+        # Group relevant capture names by (start_byte, end_byte)
+        range_captures: dict[tuple[int, int], list[str]] = {}
+        range_node: dict[tuple[int, int], Node] = {}
+        for capture_name, nodes in captures.items():
+            if capture_name not in _CAPTURE_PRIORITY:
+                continue
+            for node in nodes:
+                key = (node.start_byte, node.end_byte)
+                range_captures.setdefault(key, []).append(capture_name)
+                range_node.setdefault(key, node)
+
+        # Build sorted token list
+        raw: list[tuple[int, int, int, int, int]] = []
+        for key, names in range_captures.items():
+            best: str = min(names, key=lambda n: _CAPTURE_PRIORITY.get(n, 999))
+            type_idx, mod_bits = _CAPTURE_TOKEN[best]
+            node = range_node[key]
+            row, col = node.start_point
+            end_row, end_col = node.end_point
+            if row != end_row:
+                continue  # skip multi-line nodes
+            length = end_col - col
+            if length <= 0:
+                continue
+            raw.append((row, col, length, type_idx, mod_bits))
+
+        raw.sort(key=lambda t: (t[0], t[1]))
+
+        # Remove tokens whose range is contained within the previous token
+        # (e.g. string_content inside string — keep the outer one)
+        deduped: list[tuple[int, int, int, int, int]] = []
+        for tok in raw:
+            if deduped:
+                prev = deduped[-1]
+                if tok[0] == prev[0] and tok[1] < prev[1] + prev[2]:
+                    continue
+            deduped.append(tok)
+
+        # Delta-encode
+        data: list[int] = []
+        prev_line = prev_col = 0
+        for line, col, length, type_idx, mod_bits in deduped:
+            delta_line = line - prev_line
+            delta_col = col if delta_line else col - prev_col
+            data.extend([delta_line, delta_col, length, type_idx, mod_bits])
+            prev_line, prev_col = line, col
+
+        return lsp.SemanticTokens(data=data)
 
     @staticmethod
     def _node_text(node: Node) -> str:

--- a/src/xonsh_lsp/server.py
+++ b/src/xonsh_lsp/server.py
@@ -625,10 +625,9 @@ async def semantic_tokens_full(
     if doc is None:
         return None
 
-    parser_tokens = server.parser.get_semantic_tokens(doc.source)
+    parser_tokens = server.parser.get_semantic_tokens(server.parse_document(uri))
     backend_tokens = await server.python_delegate.get_semantic_tokens(doc.source, doc.path)
     return _merge_semantic_tokens(parser_tokens, backend_tokens)
-
 
 @server.feature(lsp.TEXT_DOCUMENT_SEMANTIC_TOKENS_RANGE)
 async def semantic_tokens_range(
@@ -640,11 +639,7 @@ async def semantic_tokens_range(
     if doc is None:
         return None
 
-    parser_tokens = server.parser.get_semantic_tokens(
-        doc.source,
-        start_line=params.range.start.line,
-        end_line=params.range.end.line,
-    )
+    parser_tokens = server.parser.get_semantic_tokens(server.parse_document(uri), params.range)
     backend_tokens = await server.python_delegate.get_semantic_tokens_range(
         doc.source,
         params.range.start.line,

--- a/src/xonsh_lsp/server.py
+++ b/src/xonsh_lsp/server.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 import argparse
 import logging
 import os
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, NamedTuple
 
 from lsprotocol import types as lsp
 from pygls.lsp.server import LanguageServer
@@ -546,60 +546,69 @@ SEMANTIC_TOKENS_LEGEND = lsp.SemanticTokensLegend(
 )
 
 
-_SemanticToken = tuple[int, int, int, int, int]
+class _SemanticToken(NamedTuple):
+    line: int
+    col: int
+    length: int
+    token_type: int
+    modifiers: int
 
 
 def _decode_semantic_tokens(tokens: lsp.SemanticTokens | None) -> list[_SemanticToken]:
     if tokens is None:
         return []
-
-    result: list[_SemanticToken] = []
+    out: list[_SemanticToken] = []
     line = col = 0
     data = tokens.data
     for i in range(0, len(data), 5):
         delta_line, delta_col, length, token_type, modifiers = data[i:i + 5]
         line += delta_line
         col = delta_col if delta_line else col + delta_col
-        result.append((line, col, length, token_type, modifiers))
-    return result
+        out.append(_SemanticToken(line, col, length, token_type, modifiers))
+    return out
 
 
 def _encode_semantic_tokens(tokens: list[_SemanticToken]) -> lsp.SemanticTokens:
+    """Delta-encode tokens. Caller must pass them sorted by (line, col)."""
     data: list[int] = []
     prev_line = prev_col = 0
-    for line, col, length, token_type, modifiers in sorted(tokens, key=lambda t: (t[0], t[1])):
-        delta_line = line - prev_line
-        delta_col = col if delta_line else col - prev_col
-        data.extend([delta_line, delta_col, length, token_type, modifiers])
-        prev_line, prev_col = line, col
+    for tok in tokens:
+        delta_line = tok.line - prev_line
+        delta_col = tok.col if delta_line else tok.col - prev_col
+        data.extend([delta_line, delta_col, tok.length, tok.token_type, tok.modifiers])
+        prev_line, prev_col = tok.line, tok.col
     return lsp.SemanticTokens(data=data)
-
-
-def _tokens_overlap(a: _SemanticToken, b: _SemanticToken) -> bool:
-    if a[0] != b[0]:
-        return False
-    return a[1] < b[1] + b[2] and b[1] < a[1] + a[2]
 
 
 def _merge_semantic_tokens(
     parser_tokens: lsp.SemanticTokens | None,
     backend_tokens: lsp.SemanticTokens | None,
 ) -> lsp.SemanticTokens | None:
+    """Combine tree-sitter parser tokens with backend tokens.
+
+    The backend (Pyright/ty) wins on overlap because it carries type-aware
+    information (class vs variable, async, etc.) that tree-sitter cannot
+    deduce syntactically.
+    """
     if parser_tokens is None:
         return backend_tokens
     if backend_tokens is None:
         return parser_tokens
 
-    parser_abs = _decode_semantic_tokens(parser_tokens)
     backend_abs = _decode_semantic_tokens(backend_tokens)
+    backend_by_line: dict[int, list[_SemanticToken]] = {}
+    for b in backend_abs:
+        backend_by_line.setdefault(b.line, []).append(b)
 
-    if not parser_abs:
-        return backend_tokens
-    if not backend_abs:
-        return parser_tokens
+    def overlaps_backend(t: _SemanticToken) -> bool:
+        for b in backend_by_line.get(t.line, ()):
+            if t.col < b.col + b.length and b.col < t.col + t.length:
+                return True
+        return False
 
-    merged = [tok for tok in parser_abs if not any(_tokens_overlap(tok, b) for b in backend_abs)]
+    merged = [t for t in _decode_semantic_tokens(parser_tokens) if not overlaps_backend(t)]
     merged.extend(backend_abs)
+    merged.sort(key=lambda t: (t.line, t.col))
     return _encode_semantic_tokens(merged)
 
 

--- a/src/xonsh_lsp/server.py
+++ b/src/xonsh_lsp/server.py
@@ -559,7 +559,7 @@ async def semantic_tokens_full(
     if doc is None:
         return None
 
-    return await server.python_delegate.get_semantic_tokens(doc.source, doc.path)
+    return server.parser.get_semantic_tokens(doc.source)
 
 
 @server.feature(lsp.TEXT_DOCUMENT_SEMANTIC_TOKENS_RANGE)
@@ -572,13 +572,10 @@ async def semantic_tokens_range(
     if doc is None:
         return None
 
-    return await server.python_delegate.get_semantic_tokens_range(
+    return server.parser.get_semantic_tokens(
         doc.source,
-        params.range.start.line,
-        params.range.start.character,
-        params.range.end.line,
-        params.range.end.character,
-        doc.path,
+        start_line=params.range.start.line,
+        end_line=params.range.end.line,
     )
 
 

--- a/src/xonsh_lsp/server.py
+++ b/src/xonsh_lsp/server.py
@@ -546,6 +546,63 @@ SEMANTIC_TOKENS_LEGEND = lsp.SemanticTokensLegend(
 )
 
 
+_SemanticToken = tuple[int, int, int, int, int]
+
+
+def _decode_semantic_tokens(tokens: lsp.SemanticTokens | None) -> list[_SemanticToken]:
+    if tokens is None:
+        return []
+
+    result: list[_SemanticToken] = []
+    line = col = 0
+    data = tokens.data
+    for i in range(0, len(data), 5):
+        delta_line, delta_col, length, token_type, modifiers = data[i:i + 5]
+        line += delta_line
+        col = delta_col if delta_line else col + delta_col
+        result.append((line, col, length, token_type, modifiers))
+    return result
+
+
+def _encode_semantic_tokens(tokens: list[_SemanticToken]) -> lsp.SemanticTokens:
+    data: list[int] = []
+    prev_line = prev_col = 0
+    for line, col, length, token_type, modifiers in sorted(tokens, key=lambda t: (t[0], t[1])):
+        delta_line = line - prev_line
+        delta_col = col if delta_line else col - prev_col
+        data.extend([delta_line, delta_col, length, token_type, modifiers])
+        prev_line, prev_col = line, col
+    return lsp.SemanticTokens(data=data)
+
+
+def _tokens_overlap(a: _SemanticToken, b: _SemanticToken) -> bool:
+    if a[0] != b[0]:
+        return False
+    return a[1] < b[1] + b[2] and b[1] < a[1] + a[2]
+
+
+def _merge_semantic_tokens(
+    parser_tokens: lsp.SemanticTokens | None,
+    backend_tokens: lsp.SemanticTokens | None,
+) -> lsp.SemanticTokens | None:
+    if parser_tokens is None:
+        return backend_tokens
+    if backend_tokens is None:
+        return parser_tokens
+
+    parser_abs = _decode_semantic_tokens(parser_tokens)
+    backend_abs = _decode_semantic_tokens(backend_tokens)
+
+    if not parser_abs:
+        return backend_tokens
+    if not backend_abs:
+        return parser_tokens
+
+    merged = [tok for tok in parser_abs if not any(_tokens_overlap(tok, b) for b in backend_abs)]
+    merged.extend(backend_abs)
+    return _encode_semantic_tokens(merged)
+
+
 @server.feature(
     lsp.TEXT_DOCUMENT_SEMANTIC_TOKENS_FULL,
     SEMANTIC_TOKENS_LEGEND,
@@ -559,7 +616,9 @@ async def semantic_tokens_full(
     if doc is None:
         return None
 
-    return server.parser.get_semantic_tokens(doc.source)
+    parser_tokens = server.parser.get_semantic_tokens(doc.source)
+    backend_tokens = await server.python_delegate.get_semantic_tokens(doc.source, doc.path)
+    return _merge_semantic_tokens(parser_tokens, backend_tokens)
 
 
 @server.feature(lsp.TEXT_DOCUMENT_SEMANTIC_TOKENS_RANGE)
@@ -572,11 +631,20 @@ async def semantic_tokens_range(
     if doc is None:
         return None
 
-    return server.parser.get_semantic_tokens(
+    parser_tokens = server.parser.get_semantic_tokens(
         doc.source,
         start_line=params.range.start.line,
         end_line=params.range.end.line,
     )
+    backend_tokens = await server.python_delegate.get_semantic_tokens_range(
+        doc.source,
+        params.range.start.line,
+        params.range.start.character,
+        params.range.end.line,
+        params.range.end.character,
+        doc.path,
+    )
+    return _merge_semantic_tokens(parser_tokens, backend_tokens)
 
 
 # ============================================================================

--- a/tests/test_parser_semantic_tokens.py
+++ b/tests/test_parser_semantic_tokens.py
@@ -33,6 +33,20 @@ def tokens_of_type(decoded: list[dict], token_type: str) -> list[dict]:
     return [t for t in decoded if t["type"] == token_type]
 
 
+def tokens(
+    parser: XonshParser, source: str, start_line: int | None = None, end_line: int | None = None,
+) -> lsp.SemanticTokens | None:
+    range_ = (
+        lsp.Range(
+            start=lsp.Position(line=start_line, character=0),
+            end=lsp.Position(line=end_line, character=0),
+        )
+        if start_line is not None and end_line is not None
+        else None
+    )
+    return parser.get_semantic_tokens(parser.parse(source), range_)
+
+
 class TestParserSemanticTokens:
 
     @pytest.fixture
@@ -40,7 +54,7 @@ class TestParserSemanticTokens:
         return XonshParser()
 
     def test_empty_source(self, parser):
-        result = parser.get_semantic_tokens("")
+        result = tokens(parser, "")
         if result is None:
             pytest.skip("tree-sitter-xonsh not available")
         assert result.data == []
@@ -48,10 +62,10 @@ class TestParserSemanticTokens:
     def test_returns_none_without_tree_sitter(self):
         p = XonshParser()
         p._initialized = False
-        assert p.get_semantic_tokens("x = 1") is None
+        assert p.get_semantic_tokens(None) is None
 
     def test_python_keyword(self, parser):
-        result = parser.get_semantic_tokens("def foo(): pass")
+        result = tokens(parser, "def foo(): pass")
         if result is None:
             pytest.skip("tree-sitter-xonsh not available")
         decoded = decode_tokens(result, "def foo(): pass")
@@ -60,7 +74,7 @@ class TestParserSemanticTokens:
         assert "pass" in keywords
 
     def test_function_definition(self, parser):
-        result = parser.get_semantic_tokens("def greet(name): pass")
+        result = tokens(parser, "def greet(name): pass")
         if result is None:
             pytest.skip("tree-sitter-xonsh not available")
         decoded = decode_tokens(result, "def greet(name): pass")
@@ -69,7 +83,7 @@ class TestParserSemanticTokens:
 
     def test_import(self, parser):
         source = "import os"
-        result = parser.get_semantic_tokens(source)
+        result = tokens(parser, source)
         if result is None:
             pytest.skip("tree-sitter-xonsh not available")
         decoded = decode_tokens(result, source)
@@ -78,7 +92,7 @@ class TestParserSemanticTokens:
 
     def test_string_no_duplicates(self, parser):
         source = "x = 'hello'"
-        result = parser.get_semantic_tokens(source)
+        result = tokens(parser, source)
         if result is None:
             pytest.skip("tree-sitter-xonsh not available")
         decoded = decode_tokens(result, source)
@@ -89,7 +103,7 @@ class TestParserSemanticTokens:
 
     def test_number(self, parser):
         source = "x = 42"
-        result = parser.get_semantic_tokens(source)
+        result = tokens(parser, source)
         if result is None:
             pytest.skip("tree-sitter-xonsh not available")
         decoded = decode_tokens(result, source)
@@ -97,7 +111,7 @@ class TestParserSemanticTokens:
 
     def test_operator(self, parser):
         source = "x = 1 + 2"
-        result = parser.get_semantic_tokens(source)
+        result = tokens(parser, source)
         if result is None:
             pytest.skip("tree-sitter-xonsh not available")
         decoded = decode_tokens(result, source)
@@ -107,7 +121,7 @@ class TestParserSemanticTokens:
 
     def test_env_variable(self, parser):
         source = "$HOME"
-        result = parser.get_semantic_tokens(source)
+        result = tokens(parser, source)
         if result is None:
             pytest.skip("tree-sitter-xonsh not available")
         decoded = decode_tokens(result, source)
@@ -117,7 +131,7 @@ class TestParserSemanticTokens:
 
     def test_subprocess_command(self, parser):
         source = "ls -la"
-        result = parser.get_semantic_tokens(source)
+        result = tokens(parser, source)
         if result is None:
             pytest.skip("tree-sitter-xonsh not available")
         decoded = decode_tokens(result, source)
@@ -125,7 +139,7 @@ class TestParserSemanticTokens:
 
     def test_subprocess_flag_is_parameter(self, parser):
         source = "ls -la"
-        result = parser.get_semantic_tokens(source)
+        result = tokens(parser, source)
         if result is None:
             pytest.skip("tree-sitter-xonsh not available")
         decoded = decode_tokens(result, source)
@@ -133,7 +147,7 @@ class TestParserSemanticTokens:
 
     def test_tokens_sorted_by_position(self, parser):
         source = "import os\nx = 1\n"
-        result = parser.get_semantic_tokens(source)
+        result = tokens(parser, source)
         if result is None:
             pytest.skip("tree-sitter-xonsh not available")
         decoded = decode_tokens(result, source)
@@ -142,7 +156,7 @@ class TestParserSemanticTokens:
 
     def test_no_overlapping_tokens(self, parser):
         source = "x = 'hello world'\n"
-        result = parser.get_semantic_tokens(source)
+        result = tokens(parser, source)
         if result is None:
             pytest.skip("tree-sitter-xonsh not available")
         decoded = decode_tokens(result, source)
@@ -155,8 +169,8 @@ class TestParserSemanticTokens:
 
     def test_range_subset(self, parser):
         source = "import os\nx = 1\nls -la\n"
-        full = parser.get_semantic_tokens(source)
-        ranged = parser.get_semantic_tokens(source, start_line=1, end_line=1)
+        full = tokens(parser, source)
+        ranged = tokens(parser, source, start_line=1, end_line=1)
         if full is None or ranged is None:
             pytest.skip("tree-sitter-xonsh not available")
         full_decoded = decode_tokens(full, source)
@@ -168,7 +182,7 @@ class TestParserSemanticTokens:
 
     def test_builtin_function_has_default_library_modifier(self, parser):
         source = "print('hi')"
-        result = parser.get_semantic_tokens(source)
+        result = tokens(parser, source)
         if result is None:
             pytest.skip("tree-sitter-xonsh not available")
         decoded = decode_tokens(result, source)

--- a/tests/test_parser_semantic_tokens.py
+++ b/tests/test_parser_semantic_tokens.py
@@ -1,0 +1,178 @@
+"""Tests for semantic token generation."""
+
+import pytest
+from lsprotocol import types as lsp
+from xonsh_lsp.parser import XonshParser
+
+
+def decode_tokens(tokens: lsp.SemanticTokens, source: str) -> list[dict]:
+    """Decode delta-encoded semantic tokens into readable dicts."""
+    type_names = [t.value for t in lsp.SemanticTokenTypes]
+    mod_names = [m.value for m in lsp.SemanticTokenModifiers]
+    lines = source.splitlines()
+    result = []
+    prev_line = prev_col = 0
+    data = tokens.data
+    for i in range(0, len(data), 5):
+        dl, dc, length, ti, mod_bits = data[i:i+5]
+        line = prev_line + dl
+        col = dc if dl else prev_col + dc
+        text = lines[line][col:col+length] if line < len(lines) else ""
+        modifiers = [mod_names[j] for j in range(len(mod_names)) if mod_bits & (1 << j)]
+        result.append({
+            "line": line, "col": col, "length": length,
+            "type": type_names[ti] if ti < len(type_names) else str(ti),
+            "modifiers": modifiers,
+            "text": text,
+        })
+        prev_line, prev_col = line, col
+    return result
+
+
+def tokens_of_type(decoded: list[dict], token_type: str) -> list[dict]:
+    return [t for t in decoded if t["type"] == token_type]
+
+
+class TestParserSemanticTokens:
+
+    @pytest.fixture
+    def parser(self):
+        return XonshParser()
+
+    def test_empty_source(self, parser):
+        result = parser.get_semantic_tokens("")
+        if result is None:
+            pytest.skip("tree-sitter-xonsh not available")
+        assert result.data == []
+
+    def test_returns_none_without_tree_sitter(self):
+        p = XonshParser()
+        p._initialized = False
+        assert p.get_semantic_tokens("x = 1") is None
+
+    def test_python_keyword(self, parser):
+        result = parser.get_semantic_tokens("def foo(): pass")
+        if result is None:
+            pytest.skip("tree-sitter-xonsh not available")
+        decoded = decode_tokens(result, "def foo(): pass")
+        keywords = [t["text"] for t in tokens_of_type(decoded, "keyword")]
+        assert "def" in keywords
+        assert "pass" in keywords
+
+    def test_function_definition(self, parser):
+        result = parser.get_semantic_tokens("def greet(name): pass")
+        if result is None:
+            pytest.skip("tree-sitter-xonsh not available")
+        decoded = decode_tokens(result, "def greet(name): pass")
+        assert any(t["text"] == "greet" and t["type"] == "function" for t in decoded)
+        assert any(t["text"] == "name" and t["type"] == "parameter" for t in decoded)
+
+    def test_import(self, parser):
+        source = "import os"
+        result = parser.get_semantic_tokens(source)
+        if result is None:
+            pytest.skip("tree-sitter-xonsh not available")
+        decoded = decode_tokens(result, source)
+        assert any(t["text"] == "import" and t["type"] == "keyword" for t in decoded)
+        assert any(t["text"] == "os" and t["type"] == "namespace" for t in decoded)
+
+    def test_string_no_duplicates(self, parser):
+        source = "x = 'hello'"
+        result = parser.get_semantic_tokens(source)
+        if result is None:
+            pytest.skip("tree-sitter-xonsh not available")
+        decoded = decode_tokens(result, source)
+        strings = tokens_of_type(decoded, "string")
+        # outer string node and inner string_content must not both appear
+        assert len(strings) == 1
+        assert strings[0]["text"] == "'hello'"
+
+    def test_number(self, parser):
+        source = "x = 42"
+        result = parser.get_semantic_tokens(source)
+        if result is None:
+            pytest.skip("tree-sitter-xonsh not available")
+        decoded = decode_tokens(result, source)
+        assert any(t["text"] == "42" and t["type"] == "number" for t in decoded)
+
+    def test_operator(self, parser):
+        source = "x = 1 + 2"
+        result = parser.get_semantic_tokens(source)
+        if result is None:
+            pytest.skip("tree-sitter-xonsh not available")
+        decoded = decode_tokens(result, source)
+        ops = [t["text"] for t in tokens_of_type(decoded, "operator")]
+        assert "+" in ops
+        assert "=" in ops
+
+    def test_env_variable(self, parser):
+        source = "$HOME"
+        result = parser.get_semantic_tokens(source)
+        if result is None:
+            pytest.skip("tree-sitter-xonsh not available")
+        decoded = decode_tokens(result, source)
+        assert any(t["text"] == "HOME" and t["type"] == "variable" for t in decoded)
+        home = next(t for t in decoded if t["text"] == "HOME")
+        assert "defaultLibrary" in home["modifiers"]
+
+    def test_subprocess_command(self, parser):
+        source = "ls -la"
+        result = parser.get_semantic_tokens(source)
+        if result is None:
+            pytest.skip("tree-sitter-xonsh not available")
+        decoded = decode_tokens(result, source)
+        assert any(t["text"] == "ls" and t["type"] == "function" for t in decoded)
+
+    def test_subprocess_flag_is_parameter(self, parser):
+        source = "ls -la"
+        result = parser.get_semantic_tokens(source)
+        if result is None:
+            pytest.skip("tree-sitter-xonsh not available")
+        decoded = decode_tokens(result, source)
+        assert any(t["text"] == "-la" and t["type"] == "parameter" for t in decoded)
+
+    def test_tokens_sorted_by_position(self, parser):
+        source = "import os\nx = 1\n"
+        result = parser.get_semantic_tokens(source)
+        if result is None:
+            pytest.skip("tree-sitter-xonsh not available")
+        decoded = decode_tokens(result, source)
+        positions = [(t["line"], t["col"]) for t in decoded]
+        assert positions == sorted(positions)
+
+    def test_no_overlapping_tokens(self, parser):
+        source = "x = 'hello world'\n"
+        result = parser.get_semantic_tokens(source)
+        if result is None:
+            pytest.skip("tree-sitter-xonsh not available")
+        decoded = decode_tokens(result, source)
+        for i in range(len(decoded) - 1):
+            a, b = decoded[i], decoded[i + 1]
+            if a["line"] == b["line"]:
+                assert a["col"] + a["length"] <= b["col"], (
+                    f"overlapping tokens: {a} and {b}"
+                )
+
+    def test_range_subset(self, parser):
+        source = "import os\nx = 1\nls -la\n"
+        full = parser.get_semantic_tokens(source)
+        ranged = parser.get_semantic_tokens(source, start_line=1, end_line=1)
+        if full is None or ranged is None:
+            pytest.skip("tree-sitter-xonsh not available")
+        full_decoded = decode_tokens(full, source)
+        range_decoded = decode_tokens(ranged, source)
+        range_lines = {t["line"] for t in range_decoded}
+        assert range_lines <= {1}
+        full_on_line1 = [t for t in full_decoded if t["line"] == 1]
+        assert range_decoded == full_on_line1
+
+    def test_builtin_function_has_default_library_modifier(self, parser):
+        source = "print('hi')"
+        result = parser.get_semantic_tokens(source)
+        if result is None:
+            pytest.skip("tree-sitter-xonsh not available")
+        decoded = decode_tokens(result, source)
+        print_tok = next((t for t in decoded if t["text"] == "print"), None)
+        assert print_tok is not None
+        assert print_tok["type"] == "function"
+        assert "defaultLibrary" in print_tok["modifiers"]

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -33,6 +33,12 @@ async def test_semantic_tokens_full_uses_python_backend(
     # Given
     monkeypatch.setattr(server_module.server, "get_document", lambda uri: document)
     monkeypatch.setattr(server_module.server, "python_backend", backend)
+    monkeypatch.setattr(
+        server_module.server.parser,
+        "get_semantic_tokens",
+        lambda source: None,
+        raising=False,
+    )
 
     # When
     result = await server_module.semantic_tokens_full(
@@ -47,6 +53,56 @@ async def test_semantic_tokens_full_uses_python_backend(
 
 
 @pytest.mark.asyncio
+async def test_semantic_tokens_merge_backend_over_parser_overlap(monkeypatch, document, backend):
+    # Given
+    monkeypatch.setattr(server_module.server, "get_document", lambda uri: document)
+    monkeypatch.setattr(server_module.server, "python_backend", backend)
+    monkeypatch.setattr(
+        server_module.server.parser,
+        "get_semantic_tokens",
+        lambda source: lsp.SemanticTokens(data=[0, 0, 7, 8, 0, 1, 0, 2, 12, 0]),
+    )
+
+    # When
+    result = await server_module.semantic_tokens_full(
+        lsp.SemanticTokensParams(
+            text_document=lsp.TextDocumentIdentifier(uri="file:///test/file.xsh")
+        )
+    )
+
+    # Then
+    assert result == lsp.SemanticTokens(data=[0, 0, 7, 5, 0, 1, 0, 2, 12, 0])
+
+
+@pytest.mark.asyncio
+async def test_semantic_tokens_full_uses_parser_tokens_when_backend_has_no_tokens(
+    monkeypatch,
+    document,
+    backend,
+):
+    # Given
+    backend.get_semantic_tokens.return_value = None
+    monkeypatch.setattr(server_module.server, "get_document", lambda uri: document)
+    monkeypatch.setattr(server_module.server, "python_backend", backend)
+    monkeypatch.setattr(
+        server_module.server.parser,
+        "get_semantic_tokens",
+        lambda source: lsp.SemanticTokens(data=[1, 0, 2, 12, 0]),
+    )
+
+    # When
+    result = await server_module.semantic_tokens_full(
+        lsp.SemanticTokensParams(
+            text_document=lsp.TextDocumentIdentifier(uri="file:///test/file.xsh")
+        )
+    )
+
+    # Then
+    backend.get_semantic_tokens.assert_awaited_once_with(document.source, document.path)
+    assert result == lsp.SemanticTokens(data=[1, 0, 2, 12, 0])
+
+
+@pytest.mark.asyncio
 async def test_semantic_tokens_range_uses_python_backend(
     monkeypatch,
     document,
@@ -55,6 +111,12 @@ async def test_semantic_tokens_range_uses_python_backend(
     # Given
     monkeypatch.setattr(server_module.server, "get_document", lambda uri: document)
     monkeypatch.setattr(server_module.server, "python_backend", backend)
+    monkeypatch.setattr(
+        server_module.server.parser,
+        "get_semantic_tokens",
+        lambda source, start_line=None, end_line=None: None,
+        raising=False,
+    )
     range_ = lsp.Range(
         start=lsp.Position(line=0, character=0),
         end=lsp.Position(line=0, character=9),

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -9,7 +9,7 @@ import xonsh_lsp.server as server_module
 
 @pytest.fixture
 def document():
-    return SimpleNamespace(source="MyClass()\nls -la\n", path="/test/file.xsh")
+    return SimpleNamespace(source="MyClass()\nls -la\n", path="/test/file.xsh", version=1)
 
 
 @pytest.fixture
@@ -36,7 +36,7 @@ async def test_semantic_tokens_full_uses_python_backend(
     monkeypatch.setattr(
         server_module.server.parser,
         "get_semantic_tokens",
-        lambda source: None,
+        lambda *args, **kwargs: None,
         raising=False,
     )
 
@@ -60,7 +60,7 @@ async def test_semantic_tokens_merge_backend_over_parser_overlap(monkeypatch, do
     monkeypatch.setattr(
         server_module.server.parser,
         "get_semantic_tokens",
-        lambda source: lsp.SemanticTokens(data=[0, 0, 7, 8, 0, 1, 0, 2, 12, 0]),
+        lambda *args, **kwargs: lsp.SemanticTokens(data=[0, 0, 7, 8, 0, 1, 0, 2, 12, 0]),
     )
 
     # When
@@ -87,7 +87,7 @@ async def test_semantic_tokens_full_uses_parser_tokens_when_backend_has_no_token
     monkeypatch.setattr(
         server_module.server.parser,
         "get_semantic_tokens",
-        lambda source: lsp.SemanticTokens(data=[1, 0, 2, 12, 0]),
+        lambda *args, **kwargs: lsp.SemanticTokens(data=[1, 0, 2, 12, 0]),
     )
 
     # When
@@ -114,7 +114,7 @@ async def test_semantic_tokens_range_uses_python_backend(
     monkeypatch.setattr(
         server_module.server.parser,
         "get_semantic_tokens",
-        lambda source, start_line=None, end_line=None: None,
+        lambda *args, **kwargs: None,
         raising=False,
     )
     range_ = lsp.Range(

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,0 +1,80 @@
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+from lsprotocol import types as lsp
+
+import xonsh_lsp.server as server_module
+
+
+@pytest.fixture
+def document():
+    return SimpleNamespace(source="MyClass()\nls -la\n", path="/test/file.xsh")
+
+
+@pytest.fixture
+def backend():
+    backend = SimpleNamespace()
+    backend.get_semantic_tokens = AsyncMock(
+        return_value=lsp.SemanticTokens(data=[0, 0, 7, 5, 0])
+    )
+    backend.get_semantic_tokens_range = AsyncMock(
+        return_value=lsp.SemanticTokens(data=[0, 0, 7, 5, 0])
+    )
+    return backend
+
+
+@pytest.mark.asyncio
+async def test_semantic_tokens_full_uses_python_backend(
+    monkeypatch,
+    document,
+    backend,
+):
+    # Given
+    monkeypatch.setattr(server_module.server, "get_document", lambda uri: document)
+    monkeypatch.setattr(server_module.server, "python_backend", backend)
+
+    # When
+    result = await server_module.semantic_tokens_full(
+        lsp.SemanticTokensParams(
+            text_document=lsp.TextDocumentIdentifier(uri="file:///test/file.xsh")
+        )
+    )
+
+    # Then
+    backend.get_semantic_tokens.assert_awaited_once_with(document.source, document.path)
+    assert result == lsp.SemanticTokens(data=[0, 0, 7, 5, 0])
+
+
+@pytest.mark.asyncio
+async def test_semantic_tokens_range_uses_python_backend(
+    monkeypatch,
+    document,
+    backend,
+):
+    # Given
+    monkeypatch.setattr(server_module.server, "get_document", lambda uri: document)
+    monkeypatch.setattr(server_module.server, "python_backend", backend)
+    range_ = lsp.Range(
+        start=lsp.Position(line=0, character=0),
+        end=lsp.Position(line=0, character=9),
+    )
+
+    # When
+    result = await server_module.semantic_tokens_range(
+        lsp.SemanticTokensRangeParams(
+            text_document=lsp.TextDocumentIdentifier(uri="file:///test/file.xsh"),
+            range=range_,
+        )
+    )
+
+    # Then
+    backend.get_semantic_tokens_range.assert_awaited_once_with(
+        document.source,
+        0,
+        0,
+        0,
+        9,
+        document.path,
+    )
+    assert result == lsp.SemanticTokens(data=[0, 0, 7, 5, 0])

--- a/uv.lock
+++ b/uv.lock
@@ -551,15 +551,15 @@ wheels = [
 
 [[package]]
 name = "tree-sitter-xonsh"
-version = "0.1.7"
+version = "0.2.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/85/6d/49463a66b3bf14e383a4b104eb22e46090c6fcf1b222a1fb43bdb4a24dc0/tree_sitter_xonsh-0.1.7.tar.gz", hash = "sha256:1e241adfb54263262c7e1970a110c01b40bcb3bd0c382bb1cb899b020bdf10fd", size = 344947, upload-time = "2026-02-15T16:42:43.664Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/84/49/97af23fa99c22ed6d2d405edfae26a5c3586810be513f339127a76a9c89c/tree_sitter_xonsh-0.2.0.tar.gz", hash = "sha256:a833ac315a15e8a7f549d75a5375a1ed9b71d80a27a7cf890a73a1c0220468c0", size = 344994, upload-time = "2026-02-16T20:50:30.795Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/bd/de/17eb72f6a6f36413a7ac757629a2846fade8c62a6c40d4cb35320b705a94/tree_sitter_xonsh-0.1.7-cp38-abi3-macosx_10_9_x86_64.whl", hash = "sha256:316ba14f373c17a274e47638426270e8cd4411d0e38a65cf67f3f91f4cc8eb42", size = 131811, upload-time = "2026-02-15T16:42:35.169Z" },
-    { url = "https://files.pythonhosted.org/packages/3f/5f/232207f01b6cf1d89951698e2ce9dd85cfdafb1cab68e52cae1d8691223f/tree_sitter_xonsh-0.1.7-cp38-abi3-macosx_11_0_arm64.whl", hash = "sha256:5aa85242571fde22ee2ec7ac682b6c9992312f365d5fb76c3f2a7418a0a0a7c5", size = 142760, upload-time = "2026-02-15T16:42:36.548Z" },
-    { url = "https://files.pythonhosted.org/packages/cb/d3/0fc8cec59d27dce6615fb22bdb2a620dfb0f9750beff6511ef19e6a9247c/tree_sitter_xonsh-0.1.7-cp38-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:97ecc55d7f97f165ebedc569186ae7e11b34da214c0cdb0277ec7612627e2195", size = 184454, upload-time = "2026-02-15T16:42:39.859Z" },
-    { url = "https://files.pythonhosted.org/packages/87/9e/ce0bf6be175588c0dc83220fb5ceb5933d2a87b324e75477f5a2d458e898/tree_sitter_xonsh-0.1.7-cp38-abi3-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:13ede1e1412a5773018485a4d191968c1aaa2f7b53440dcf0f2203b999410641", size = 173285, upload-time = "2026-02-15T16:42:40.954Z" },
-    { url = "https://files.pythonhosted.org/packages/53/5c/33beafb8e97612d3ed13edf066e48c2042805b78507f1d976ecb997b5a31/tree_sitter_xonsh-0.1.7-cp38-abi3-win_amd64.whl", hash = "sha256:7fbfac6df20098c34d555a859c14d50d134f6cbf25c149277407196192187463", size = 135272, upload-time = "2026-02-15T16:42:42.538Z" },
+    { url = "https://files.pythonhosted.org/packages/30/c8/539b42bffe1b244d054232e24d6cc76a6db274dd82d12b57da0bd3885f7c/tree_sitter_xonsh-0.2.0-cp38-abi3-macosx_10_9_x86_64.whl", hash = "sha256:1aed49e7eec3f191cede7f99071ccdce0c22d74c4f4de325799f883667c4e23b", size = 131691, upload-time = "2026-02-16T20:50:23.972Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/ba/527a7e22d6263ffe74f1b4ae93cde5a5dd65ae833c9d6a45d270d8dcb45c/tree_sitter_xonsh-0.2.0-cp38-abi3-macosx_11_0_arm64.whl", hash = "sha256:7e2ad92fec25bce338d5f3a986f1ad9b29a4a96a8dfb76b583e68ee63d99ad48", size = 142669, upload-time = "2026-02-16T20:50:25.216Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/cb/30359ba88cdc2f9dc5da898e72c44c7f1e83a3fbee95d63c8726b6bf98ae/tree_sitter_xonsh-0.2.0-cp38-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ff7abbfa8e48490817afcd7126c166a3fab57f54da1c46bb1236f8b7fa228e47", size = 184329, upload-time = "2026-02-16T20:50:26.918Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/ed/5c5a6c49a668bcf93c8937c84a55b7f41bb3906f4268aaf551c65d29592b/tree_sitter_xonsh-0.2.0-cp38-abi3-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:458ba10cc090bb86c65a0dacce935c24deae4e32e3713356d87ac5e4805e4e7f", size = 173277, upload-time = "2026-02-16T20:50:28.452Z" },
+    { url = "https://files.pythonhosted.org/packages/af/5a/1bfff3fe63ec543ba4bd39705994015fd44408380594a1f3b97abcf1137d/tree_sitter_xonsh-0.2.0-cp38-abi3-win_amd64.whl", hash = "sha256:b3eff7325434c12d46ae4b61dbcb3b381cbdabd258032215de728289cdb6e03b", size = 135310, upload-time = "2026-02-16T20:50:29.582Z" },
 ]
 
 [[package]]
@@ -573,7 +573,7 @@ wheels = [
 
 [[package]]
 name = "xonsh-lsp"
-version = "0.1.7"
+version = "0.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "cattrs" },
@@ -613,6 +613,6 @@ requires-dist = [
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=4.0.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.1.0" },
     { name = "tree-sitter", specifier = ">=0.25.2" },
-    { name = "tree-sitter-xonsh", specifier = ">=0.1.7" },
+    { name = "tree-sitter-xonsh", specifier = ">=0.2.0" },
 ]
 provides-extras = ["jedi", "all", "dev"]


### PR DESCRIPTION
This PR makes it possible to implement syntax highlighting for all xonsh code using this server, including with the built-in Jedi backend, by returning the semantic tokens from Tree Sitter.

(The current implementation provides semantic tokens for Python parts of xonsh code only, and only when using an external backend, not Jedi.)

The code is >95% written by Claude and GPT. I iterated* until it looked sane overall. However, I didn't double check every line. Feel free to make low-effort comments if you deem the code not up to standards.

Cheers