### PR TITLE
Reuse cached parse tree for symbols and folding ranges

### DIFF
--- a/src/xonsh_lsp/parser.py
+++ b/src/xonsh_lsp/parser.py
@@ -545,16 +545,15 @@ class XonshParser:
         "list", "dictionary", "set", "tuple",
     }
 
-    def get_folding_ranges(self, source: str) -> list[dict]:
-        """Extract folding ranges from source code.
+    def get_folding_ranges(self, parse_result: ParseResult | None) -> list[dict]:
+        """Extract folding ranges from a parsed document.
 
         Returns a list of dicts with keys:
         - start_line: 0-based start line
         - end_line: 0-based end line
         - kind: "region", "comment", or "imports"
         """
-        result = self.parse(source)
-        if result.tree is None:
+        if parse_result is None or parse_result.tree is None:
             return []
 
         ranges: list[dict] = []
@@ -610,12 +609,12 @@ class XonshParser:
             for child in node.children:
                 visit(child)
 
-        visit(result.tree.root_node)
+        visit(parse_result.tree.root_node)
         flush_comments()
         return ranges
 
-    def get_document_symbols(self, source: str) -> list[dict]:
-        """Extract document symbols from source code.
+    def get_document_symbols(self, parse_result: ParseResult | None) -> list[dict]:
+        """Extract document symbols from a parsed document.
 
         Returns a list of symbol dicts with keys:
         - name: symbol name
@@ -626,8 +625,7 @@ class XonshParser:
         - end_col: 0-based end column
         - detail: optional detail string
         """
-        result = self.parse(source)
-        if result.tree is None:
+        if parse_result is None or parse_result.tree is None:
             return []
 
         symbols = []
@@ -779,7 +777,7 @@ class XonshParser:
             for child in node.children:
                 visit(child)
 
-        visit(result.tree.root_node)
+        visit(parse_result.tree.root_node)
         return symbols
 
     def get_macro_name(self, node_info: NodeInfo) -> str | None:

--- a/src/xonsh_lsp/server.py
+++ b/src/xonsh_lsp/server.py
@@ -420,12 +420,11 @@ async def document_symbols(
 ) -> list[lsp.DocumentSymbol] | list[lsp.SymbolInformation] | None:
     """Provide document symbols."""
     uri = params.text_document.uri
-    doc = server.get_document(uri)
-    if doc is None:
+    if server.get_document(uri) is None:
         return None
 
     # Use tree-sitter for symbol extraction (handles xonsh syntax)
-    raw_symbols = server.parser.get_document_symbols(doc.source)
+    raw_symbols = server.parser.get_document_symbols(server.parse_document(uri))
 
     # Convert to LSP DocumentSymbol format
     kind_map = {
@@ -466,11 +465,10 @@ async def document_symbols(
 async def folding_range(params: lsp.FoldingRangeParams) -> list[lsp.FoldingRange] | None:
     """Provide folding ranges."""
     uri = params.text_document.uri
-    doc = server.get_document(uri)
-    if doc is None:
+    if server.get_document(uri) is None:
         return None
 
-    raw_ranges = server.parser.get_folding_ranges(doc.source)
+    raw_ranges = server.parser.get_folding_ranges(server.parse_document(uri))
 
     kind_map = {
         "comment": lsp.FoldingRangeKind.Comment,

--- a/tests/test_document_symbols.py
+++ b/tests/test_document_symbols.py
@@ -21,7 +21,7 @@ def greet(name):
 def farewell():
     print("Goodbye!")
 """
-        symbols = parser.get_document_symbols(source)
+        symbols = parser.get_document_symbols(parser.parse(source))
         function_symbols = [s for s in symbols if s["kind"] == "function"]
         names = [s["name"] for s in function_symbols]
         assert "greet" in names
@@ -37,7 +37,7 @@ class MyClass:
 class AnotherClass:
     pass
 """
-        symbols = parser.get_document_symbols(source)
+        symbols = parser.get_document_symbols(parser.parse(source))
         class_symbols = [s for s in symbols if s["kind"] == "class"]
         names = [s["name"] for s in class_symbols]
         assert "MyClass" in names
@@ -50,7 +50,7 @@ x = 1
 my_variable = "hello"
 result = calculate()
 """
-        symbols = parser.get_document_symbols(source)
+        symbols = parser.get_document_symbols(parser.parse(source))
         var_symbols = [s for s in symbols if s["kind"] == "variable"]
         names = [s["name"] for s in var_symbols]
         assert "x" in names
@@ -65,7 +65,7 @@ path = ${PATH}
 files = $(ls -la)
 result = !(git status)
 """
-        symbols = parser.get_document_symbols(source)
+        symbols = parser.get_document_symbols(parser.parse(source))
         var_symbols = [s for s in symbols if s["kind"] == "variable"]
         names = [s["name"] for s in var_symbols]
         assert "home" in names
@@ -76,7 +76,7 @@ result = !(git status)
     def test_variable_details(self, parser):
         """Test that variable details contain RHS."""
         source = 'name = "world"'
-        symbols = parser.get_document_symbols(source)
+        symbols = parser.get_document_symbols(parser.parse(source))
         var_symbols = [s for s in symbols if s["kind"] == "variable"]
         assert len(var_symbols) == 1
         assert var_symbols[0]["name"] == "name"
@@ -85,7 +85,7 @@ result = !(git status)
     def test_xonsh_variable_details(self, parser):
         """Test that xonsh variable details show xonsh syntax."""
         source = "home = $HOME"
-        symbols = parser.get_document_symbols(source)
+        symbols = parser.get_document_symbols(parser.parse(source))
         var_symbols = [s for s in symbols if s["kind"] == "variable"]
         assert len(var_symbols) == 1
         assert var_symbols[0]["name"] == "home"
@@ -97,7 +97,7 @@ result = !(git status)
 import os
 import sys
 """
-        symbols = parser.get_document_symbols(source)
+        symbols = parser.get_document_symbols(parser.parse(source))
         module_symbols = [s for s in symbols if s["kind"] == "module"]
         names = [s["name"] for s in module_symbols]
         assert "os" in names
@@ -117,7 +117,7 @@ def greet():
 class MyClass:
     pass
 """
-        symbols = parser.get_document_symbols(source)
+        symbols = parser.get_document_symbols(parser.parse(source))
 
         # Check all types are present
         kinds = set(s["kind"] for s in symbols)
@@ -134,7 +134,7 @@ class MyClass:
 def second():
     pass
 """
-        symbols = parser.get_document_symbols(source)
+        symbols = parser.get_document_symbols(parser.parse(source))
         function_symbols = [s for s in symbols if s["kind"] == "function"]
 
         first_func = next(s for s in function_symbols if s["name"] == "first")
@@ -145,7 +145,7 @@ def second():
 
     def test_empty_source(self, parser):
         """Test document symbols for empty source."""
-        symbols = parser.get_document_symbols("")
+        symbols = parser.get_document_symbols(parser.parse(""))
         assert symbols == []
 
     def test_comment_only_source(self, parser):
@@ -154,14 +154,14 @@ def second():
 # This is a comment
 # Another comment
 """
-        symbols = parser.get_document_symbols(source)
+        symbols = parser.get_document_symbols(parser.parse(source))
         assert symbols == []
 
     def test_long_detail_truncation(self, parser):
         """Test that long details are truncated."""
         long_value = "x" * 100
         source = f'var = "{long_value}"'
-        symbols = parser.get_document_symbols(source)
+        symbols = parser.get_document_symbols(parser.parse(source))
         var_symbols = [s for s in symbols if s["kind"] == "variable"]
         assert len(var_symbols) == 1
         # Detail should be truncated
@@ -175,7 +175,7 @@ def outer():
         pass
     return inner
 """
-        symbols = parser.get_document_symbols(source)
+        symbols = parser.get_document_symbols(parser.parse(source))
         function_symbols = [s for s in symbols if s["kind"] == "function"]
         names = [s["name"] for s in function_symbols]
         # Should include both outer and inner (we traverse all nodes)

--- a/tests/test_folding_ranges.py
+++ b/tests/test_folding_ranges.py
@@ -15,14 +15,14 @@ class TestFoldingRanges:
     def test_function_folding(self, parser):
         """Test that multi-line functions produce a fold."""
         source = "def greet(name):\n    print(name)\n    return name\n"
-        ranges = parser.get_folding_ranges(source)
+        ranges = parser.get_folding_ranges(parser.parse(source))
         folds = [r for r in ranges if r["kind"] == "region"]
         assert any(r["start_line"] == 0 and r["end_line"] == 2 for r in folds)
 
     def test_single_line_function_no_fold(self, parser):
         """Test that single-line constructs produce no fold."""
         source = "def f(): pass\n"
-        ranges = parser.get_folding_ranges(source)
+        ranges = parser.get_folding_ranges(parser.parse(source))
         func_folds = [
             r for r in ranges
             if r["kind"] == "region" and r["start_line"] == 0
@@ -32,14 +32,14 @@ class TestFoldingRanges:
     def test_class_folding(self, parser):
         """Test that multi-line classes produce a fold."""
         source = "class MyClass:\n    x = 1\n    y = 2\n"
-        ranges = parser.get_folding_ranges(source)
+        ranges = parser.get_folding_ranges(parser.parse(source))
         folds = [r for r in ranges if r["kind"] == "region"]
         assert any(r["start_line"] == 0 for r in folds)
 
     def test_nested_functions(self, parser):
         """Test that nested functions both produce folds."""
         source = "def outer():\n    def inner():\n        pass\n    return inner\n"
-        ranges = parser.get_folding_ranges(source)
+        ranges = parser.get_folding_ranges(parser.parse(source))
         region_folds = [r for r in ranges if r["kind"] == "region"]
         # Both outer and inner should fold
         starts = {r["start_line"] for r in region_folds}
@@ -56,7 +56,7 @@ class TestFoldingRanges:
             "else:\n"
             "    c = 3\n"
         )
-        ranges = parser.get_folding_ranges(source)
+        ranges = parser.get_folding_ranges(parser.parse(source))
         region_folds = [r for r in ranges if r["kind"] == "region"]
         # if_statement itself spans all lines
         assert any(r["start_line"] == 0 for r in region_folds)
@@ -64,21 +64,21 @@ class TestFoldingRanges:
     def test_for_loop(self, parser):
         """Test for loop folding."""
         source = "for i in range(10):\n    print(i)\n    print(i + 1)\n"
-        ranges = parser.get_folding_ranges(source)
+        ranges = parser.get_folding_ranges(parser.parse(source))
         folds = [r for r in ranges if r["kind"] == "region"]
         assert any(r["start_line"] == 0 for r in folds)
 
     def test_while_loop(self, parser):
         """Test while loop folding."""
         source = "while True:\n    break\n"
-        ranges = parser.get_folding_ranges(source)
+        ranges = parser.get_folding_ranges(parser.parse(source))
         folds = [r for r in ranges if r["kind"] == "region"]
         assert any(r["start_line"] == 0 for r in folds)
 
     def test_with_statement(self, parser):
         """Test with statement folding."""
         source = "with open('f') as fp:\n    data = fp.read()\n"
-        ranges = parser.get_folding_ranges(source)
+        ranges = parser.get_folding_ranges(parser.parse(source))
         folds = [r for r in ranges if r["kind"] == "region"]
         assert any(r["start_line"] == 0 for r in folds)
 
@@ -92,42 +92,42 @@ class TestFoldingRanges:
             "finally:\n"
             "    x = 3\n"
         )
-        ranges = parser.get_folding_ranges(source)
+        ranges = parser.get_folding_ranges(parser.parse(source))
         region_folds = [r for r in ranges if r["kind"] == "region"]
         assert any(r["start_line"] == 0 for r in region_folds)
 
     def test_multiline_string(self, parser):
         """Test multi-line string folding with comment kind."""
         source = 'x = """\nline1\nline2\n"""\n'
-        ranges = parser.get_folding_ranges(source)
+        ranges = parser.get_folding_ranges(parser.parse(source))
         string_folds = [r for r in ranges if r["kind"] == "comment"]
         assert any(r["start_line"] == 0 for r in string_folds)
 
     def test_multiline_list(self, parser):
         """Test multi-line list folding."""
         source = "items = [\n    1,\n    2,\n    3,\n]\n"
-        ranges = parser.get_folding_ranges(source)
+        ranges = parser.get_folding_ranges(parser.parse(source))
         folds = [r for r in ranges if r["kind"] == "region"]
         assert any(r for r in folds)
 
     def test_multiline_dict(self, parser):
         """Test multi-line dict folding."""
         source = "d = {\n    'a': 1,\n    'b': 2,\n}\n"
-        ranges = parser.get_folding_ranges(source)
+        ranges = parser.get_folding_ranges(parser.parse(source))
         folds = [r for r in ranges if r["kind"] == "region"]
         assert any(r for r in folds)
 
     def test_multiline_tuple(self, parser):
         """Test multi-line tuple folding."""
         source = "t = (\n    1,\n    2,\n)\n"
-        ranges = parser.get_folding_ranges(source)
+        ranges = parser.get_folding_ranges(parser.parse(source))
         folds = [r for r in ranges if r["kind"] == "region"]
         assert any(r for r in folds)
 
     def test_multiline_import(self, parser):
         """Test multi-line import folding with imports kind."""
         source = "from os import (\n    path,\n    getcwd,\n)\n"
-        ranges = parser.get_folding_ranges(source)
+        ranges = parser.get_folding_ranges(parser.parse(source))
         import_folds = [r for r in ranges if r["kind"] == "imports"]
         assert len(import_folds) >= 1
         assert import_folds[0]["start_line"] == 0
@@ -135,7 +135,7 @@ class TestFoldingRanges:
     def test_decorated_function(self, parser):
         """Test that decorated definitions produce a fold."""
         source = "@decorator\ndef func():\n    pass\n"
-        ranges = parser.get_folding_ranges(source)
+        ranges = parser.get_folding_ranges(parser.parse(source))
         region_folds = [r for r in ranges if r["kind"] == "region"]
         # decorated_definition should fold from line 0
         assert any(r["start_line"] == 0 for r in region_folds)
@@ -143,7 +143,7 @@ class TestFoldingRanges:
     def test_consecutive_comments(self, parser):
         """Test that consecutive comment lines produce a single fold."""
         source = "# line 1\n# line 2\n# line 3\nx = 1\n"
-        ranges = parser.get_folding_ranges(source)
+        ranges = parser.get_folding_ranges(parser.parse(source))
         comment_folds = [r for r in ranges if r["kind"] == "comment"]
         assert any(
             r["start_line"] == 0 and r["end_line"] == 2
@@ -153,32 +153,32 @@ class TestFoldingRanges:
     def test_single_comment_no_fold(self, parser):
         """Test that a single comment line does not produce a fold."""
         source = "# just one comment\nx = 1\n"
-        ranges = parser.get_folding_ranges(source)
+        ranges = parser.get_folding_ranges(parser.parse(source))
         comment_folds = [r for r in ranges if r["kind"] == "comment"]
         assert comment_folds == []
 
     def test_empty_source(self, parser):
         """Test no folds for empty source."""
-        ranges = parser.get_folding_ranges("")
+        ranges = parser.get_folding_ranges(parser.parse(""))
         assert ranges == []
 
     def test_no_foldable_regions(self, parser):
         """Test no folds when source has only single-line statements."""
         source = "x = 1\ny = 2\nz = 3\n"
-        ranges = parser.get_folding_ranges(source)
+        ranges = parser.get_folding_ranges(parser.parse(source))
         assert ranges == []
 
     def test_block_macro_statement(self, parser):
         """Test xonsh block macro folding."""
         source = "with! ctx:\n    body_line1\n    body_line2\n"
-        ranges = parser.get_folding_ranges(source)
+        ranges = parser.get_folding_ranges(parser.parse(source))
         region_folds = [r for r in ranges if r["kind"] == "region"]
         assert any(r["start_line"] == 0 for r in region_folds)
 
     def test_multiline_argument_list(self, parser):
         """Test multi-line function call arguments fold."""
         source = "func(\n    a,\n    b,\n    c,\n)\n"
-        ranges = parser.get_folding_ranges(source)
+        ranges = parser.get_folding_ranges(parser.parse(source))
         folds = [r for r in ranges if r["kind"] == "region"]
         assert any(r for r in folds)
 
@@ -191,7 +191,7 @@ class TestFoldingRanges:
             "def func2():\n"
             "    pass\n"
         )
-        ranges = parser.get_folding_ranges(source)
+        ranges = parser.get_folding_ranges(parser.parse(source))
         region_folds = [r for r in ranges if r["kind"] == "region"]
         starts = {r["start_line"] for r in region_folds}
         assert 0 in starts

--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -78,14 +78,14 @@ class TestMultiByteNodeText:
         """get_document_symbols must return correct function names even when
         the source has CJK characters above the function definition."""
         source = '# 你好世界\ndef hello():\n    pass'
-        symbols = parser.get_document_symbols(source)
+        symbols = parser.get_document_symbols(parser.parse(source))
         func_names = [s["name"] for s in symbols if s["kind"] == "function"]
         assert "hello" in func_names
 
     def test_document_symbols_variable_after_emoji(self, parser):
         """Variable name extraction must be correct after multi-byte chars."""
         source = 'emoji = "🎉"\nmy_variable = 42'
-        symbols = parser.get_document_symbols(source)
+        symbols = parser.get_document_symbols(parser.parse(source))
         var_names = [s["name"] for s in symbols if s["kind"] == "variable"]
         assert "my_variable" in var_names
 


### PR DESCRIPTION
Claude (iirc) suggested this while doing the PR you merged:

---

XonshParser.get_document_symbols and get_folding_ranges each re-parsed the source on every request, ignoring the parse cache that XonshLanguageServer.parse_document already maintains keyed by (uri, version). Take a ParseResult instead of a source string; the handlers pass the cached parse_document(uri).

Tests updated to call parser.parse(source) and forward the result.