### PR TITLE
feat: Rename Python identifiers

### DIFF
--- a/src/xonsh_lsp/jedi_backend.py
+++ b/src/xonsh_lsp/jedi_backend.py
@@ -271,6 +271,102 @@ class JediBackend:
             logger.debug(f"Jedi references error: {e}")
             return []
 
+    async def rename(
+        self,
+        source: str,
+        line: int,
+        col: int,
+        new_name: str,
+        path: str | None = None,
+    ) -> lsp.WorkspaceEdit | None:
+        """Rename a Python symbol using Jedi."""
+        if not JEDI_AVAILABLE:
+            return None
+
+        try:
+            preprocess_result = preprocess_with_mapping(source)
+            mapped_line, mapped_col = map_position_to_processed(
+                preprocess_result, line, col
+            )
+
+            script = Script(preprocess_result.source, path=path)
+            try:
+                refactoring = script.rename(
+                    mapped_line + 1, mapped_col, new_name=new_name
+                )
+            except Exception as e:
+                logger.debug(f"Jedi rename refused: {e}")
+                return None
+
+            # Jedi exposes structured ranges via parso Name nodes in the
+            # private `_file_to_node_changes` dict. The public surface
+            # (`get_diff`, `get_new_code`) only returns text, which we'd have
+            # to diff to recover ranges.
+            file_changes = getattr(refactoring, "_file_to_node_changes", None)
+            if not file_changes:
+                return None
+
+            masked = preprocess_result.masked_lines
+            changes: dict[str, list[lsp.TextEdit]] = {}
+
+            for file_path, node_changes in file_changes.items():
+                # Jedi uses None for the in-memory script's path
+                if file_path is None:
+                    if path is None:
+                        target_uri = "file:///untitled.xsh"
+                    else:
+                        target_uri = Path(path).as_uri()
+                    is_current = True
+                else:
+                    target_uri = Path(str(file_path)).as_uri()
+                    is_current = path is not None and str(file_path) == path
+
+                edits: list[lsp.TextEdit] = []
+                for node in node_changes:
+                    start_line_1, start_col = node.start_pos
+                    end_line_1, end_col = node.end_pos
+                    start_line = start_line_1 - 1
+                    end_line = end_line_1 - 1
+
+                    if is_current:
+                        orig_start_line, orig_start_col = (
+                            map_position_from_processed(
+                                preprocess_result, start_line, start_col
+                            )
+                        )
+                        orig_end_line, orig_end_col = map_position_from_processed(
+                            preprocess_result, end_line, end_col
+                        )
+                        if orig_start_line in masked:
+                            continue
+                        edit_range = lsp.Range(
+                            start=lsp.Position(
+                                line=orig_start_line, character=orig_start_col
+                            ),
+                            end=lsp.Position(
+                                line=orig_end_line, character=orig_end_col
+                            ),
+                        )
+                    else:
+                        edit_range = lsp.Range(
+                            start=lsp.Position(line=start_line, character=start_col),
+                            end=lsp.Position(line=end_line, character=end_col),
+                        )
+
+                    edits.append(lsp.TextEdit(range=edit_range, new_text=new_name))
+
+                if edits:
+                    changes.setdefault(target_uri, []).extend(edits)
+
+            if not changes:
+                return None
+
+            return lsp.WorkspaceEdit(changes=changes)
+
+        except Exception as e:
+            logger.debug(f"Jedi rename error: {e}")
+            return None
+
     async def get_diagnostics(
         self,
         source: str,

--- a/src/xonsh_lsp/jedi_backend.py
+++ b/src/xonsh_lsp/jedi_backend.py
@@ -9,17 +9,16 @@ from __future__ import annotations
 
 import logging
 from pathlib import Path
-from typing import TYPE_CHECKING
 
 from lsprotocol import types as lsp
 
 from xonsh_lsp.preprocessing import (
-    PreprocessResult,
     map_position_from_processed,
     map_position_to_processed,
     preprocess_source,
     preprocess_with_mapping,
 )
+from xonsh_lsp.python_backend_common import remap_text_edit
 
 try:
     import jedi
@@ -306,7 +305,6 @@ class JediBackend:
             if not file_changes:
                 return None
 
-            masked = preprocess_result.masked_lines
             changes: dict[str, list[lsp.TextEdit]] = {}
 
             for file_path, node_changes in file_changes.items():
@@ -325,35 +323,17 @@ class JediBackend:
                 for node in node_changes:
                     start_line_1, start_col = node.start_pos
                     end_line_1, end_col = node.end_pos
-                    start_line = start_line_1 - 1
-                    end_line = end_line_1 - 1
-
-                    if is_current:
-                        orig_start_line, orig_start_col = (
-                            map_position_from_processed(
-                                preprocess_result, start_line, start_col
-                            )
-                        )
-                        orig_end_line, orig_end_col = map_position_from_processed(
-                            preprocess_result, end_line, end_col
-                        )
-                        if orig_start_line in masked:
-                            continue
-                        edit_range = lsp.Range(
-                            start=lsp.Position(
-                                line=orig_start_line, character=orig_start_col
-                            ),
-                            end=lsp.Position(
-                                line=orig_end_line, character=orig_end_col
-                            ),
-                        )
-                    else:
-                        edit_range = lsp.Range(
-                            start=lsp.Position(line=start_line, character=start_col),
-                            end=lsp.Position(line=end_line, character=end_col),
-                        )
-
-                    edits.append(lsp.TextEdit(range=edit_range, new_text=new_name))
+                    text_edit = remap_text_edit(
+                        preprocess_result,
+                        start_line_1 - 1,
+                        start_col,
+                        end_line_1 - 1,
+                        end_col,
+                        new_name,
+                        is_current=is_current,
+                    )
+                    if text_edit is not None:
+                        edits.append(text_edit)
 
                 if edits:
                     changes.setdefault(target_uri, []).extend(edits)

--- a/src/xonsh_lsp/jedi_backend.py
+++ b/src/xonsh_lsp/jedi_backend.py
@@ -332,8 +332,13 @@ class JediBackend:
                         new_name,
                         is_current=is_current,
                     )
-                    if text_edit is not None:
-                        edits.append(text_edit)
+                    if text_edit is None:
+                        # An occurrence we cannot map back (masked xonsh
+                        # line): applying the rest would be a partial rename
+                        # that silently corrupts code, so refuse entirely.
+                        logger.debug("Unmappable rename edit; refusing rename")
+                        return None
+                    edits.append(text_edit)
 
                 if edits:
                     changes.setdefault(target_uri, []).extend(edits)

--- a/src/xonsh_lsp/lsp_proxy_backend.py
+++ b/src/xonsh_lsp/lsp_proxy_backend.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 import logging
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Callable, Optional, Union
+from typing import TYPE_CHECKING, Any, Callable, Optional, Sequence, Union
 
 from lsprotocol import types as lsp
 from pygls.lsp.client import LanguageClient
@@ -624,6 +624,117 @@ class LspProxyBackend:
         except Exception as e:
             logger.debug(f"Proxy references error: {e}")
             return []
+
+    async def rename(
+        self,
+        source: str,
+        line: int,
+        col: int,
+        new_name: str,
+        path: str | None = None,
+    ) -> lsp.WorkspaceEdit | None:
+        """Rename via the child LSP server, remapping ranges back to xonsh."""
+        if not self._started or self._client is None:
+            return None
+
+        try:
+            preprocess_result = preprocess_with_mapping(source)
+            uri = self._file_uri(path)
+            self._sync_document(source, path)
+
+            mapped_line, mapped_col = map_position_to_processed(
+                preprocess_result, line, col
+            )
+            mapped_line += self._preamble_offset(uri)
+
+            result = await self._client.text_document_rename_async(
+                lsp.RenameParams(
+                    text_document=lsp.TextDocumentIdentifier(uri=uri),
+                    position=lsp.Position(line=mapped_line, character=mapped_col),
+                    new_name=new_name,
+                )
+            )
+
+            if result is None:
+                return None
+
+            return self._remap_workspace_edit(result, preprocess_result, uri)
+
+        except Exception as e:
+            logger.debug(f"Proxy rename error: {e}")
+            return None
+
+    def _remap_workspace_edit(
+        self,
+        edit: lsp.WorkspaceEdit,
+        current_pp: PreprocessResult,
+        current_uri: str,
+    ) -> lsp.WorkspaceEdit | None:
+        """Remap a WorkspaceEdit from child coordinates to original xonsh.
+
+        Only `changes` and `TextDocumentEdit` entries in `document_changes` are
+        kept. File-level operations (create/rename/delete file) are dropped.
+        """
+        preamble = self._preamble_offset(current_uri)
+        masked = current_pp.masked_lines
+
+        def remap_edits(
+            child_uri: str, edits: Sequence[lsp.TextEdit]
+        ) -> tuple[str, list[lsp.TextEdit]]:
+            original_uri = self._uri_map.get(child_uri, child_uri)
+            is_current = child_uri == current_uri
+            remapped: list[lsp.TextEdit] = []
+            for e in edits:
+                if is_current:
+                    start_line = e.range.start.line - preamble
+                    end_line = e.range.end.line - preamble
+                    if start_line < 0:
+                        continue
+                    orig_start_line, orig_start_col = map_position_from_processed(
+                        current_pp, start_line, e.range.start.character
+                    )
+                    orig_end_line, orig_end_col = map_position_from_processed(
+                        current_pp, end_line, e.range.end.character
+                    )
+                    if orig_start_line in masked:
+                        continue
+                    new_range = lsp.Range(
+                        start=lsp.Position(
+                            line=orig_start_line, character=orig_start_col
+                        ),
+                        end=lsp.Position(
+                            line=orig_end_line, character=orig_end_col
+                        ),
+                    )
+                else:
+                    new_range = e.range
+                remapped.append(lsp.TextEdit(range=new_range, new_text=e.new_text))
+            return original_uri, remapped
+
+        changes: dict[str, list[lsp.TextEdit]] = {}
+
+        if edit.changes:
+            for child_uri, edits in edit.changes.items():
+                target_uri, remapped = remap_edits(child_uri, edits)
+                if remapped:
+                    changes.setdefault(target_uri, []).extend(remapped)
+
+        if edit.document_changes:
+            for doc_change in edit.document_changes:
+                if not isinstance(doc_change, lsp.TextDocumentEdit):
+                    continue  # drop file-level operations for now
+                child_uri = doc_change.text_document.uri
+                text_edits = [
+                    te for te in doc_change.edits if isinstance(te, lsp.TextEdit)
+                ]
+                target_uri, remapped = remap_edits(child_uri, text_edits)
+                if remapped:
+                    changes.setdefault(target_uri, []).extend(remapped)
+
+        if not changes:
+            return None
+
+        return lsp.WorkspaceEdit(changes=changes)
 
     async def get_diagnostics(
         self, source: str, path: str | None = None

--- a/src/xonsh_lsp/lsp_proxy_backend.py
+++ b/src/xonsh_lsp/lsp_proxy_backend.py
@@ -10,7 +10,7 @@ and handles asynchronous diagnostics.
 from __future__ import annotations
 
 import logging
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Callable, Optional, Sequence, Union
 
@@ -23,6 +23,7 @@ from xonsh_lsp.preprocessing import (
     map_position_to_processed,
     preprocess_with_mapping,
 )
+from xonsh_lsp.python_backend_common import remap_text_edit
 
 if TYPE_CHECKING:
     from pygls.lsp.server import LanguageServer
@@ -676,7 +677,6 @@ class LspProxyBackend:
         kept. File-level operations (create/rename/delete file) are dropped.
         """
         preamble = self._preamble_offset(current_uri)
-        masked = current_pp.masked_lines
 
         def remap_edits(
             child_uri: str, edits: Sequence[lsp.TextEdit]
@@ -685,30 +685,18 @@ class LspProxyBackend:
             is_current = child_uri == current_uri
             remapped: list[lsp.TextEdit] = []
             for e in edits:
-                if is_current:
-                    start_line = e.range.start.line - preamble
-                    end_line = e.range.end.line - preamble
-                    if start_line < 0:
-                        continue
-                    orig_start_line, orig_start_col = map_position_from_processed(
-                        current_pp, start_line, e.range.start.character
-                    )
-                    orig_end_line, orig_end_col = map_position_from_processed(
-                        current_pp, end_line, e.range.end.character
-                    )
-                    if orig_start_line in masked:
-                        continue
-                    new_range = lsp.Range(
-                        start=lsp.Position(
-                            line=orig_start_line, character=orig_start_col
-                        ),
-                        end=lsp.Position(
-                            line=orig_end_line, character=orig_end_col
-                        ),
-                    )
-                else:
-                    new_range = e.range
-                remapped.append(lsp.TextEdit(range=new_range, new_text=e.new_text))
+                text_edit = remap_text_edit(
+                    current_pp,
+                    e.range.start.line,
+                    e.range.start.character,
+                    e.range.end.line,
+                    e.range.end.character,
+                    e.new_text,
+                    is_current=is_current,
+                    preamble_offset=preamble,
+                )
+                if text_edit is not None:
+                    remapped.append(text_edit)
             return original_uri, remapped
 
         changes: dict[str, list[lsp.TextEdit]] = {}

--- a/src/xonsh_lsp/lsp_proxy_backend.py
+++ b/src/xonsh_lsp/lsp_proxy_backend.py
@@ -659,7 +659,7 @@ class LspProxyBackend:
             if result is None:
                 return None
 
-            return self._remap_workspace_edit(result, preprocess_result, uri)
+            return self._remap_workspace_edit(result)
 
         except Exception as e:
             logger.debug(f"Proxy rename error: {e}")
@@ -668,42 +668,55 @@ class LspProxyBackend:
     def _remap_workspace_edit(
         self,
         edit: lsp.WorkspaceEdit,
-        current_pp: PreprocessResult,
-        current_uri: str,
     ) -> lsp.WorkspaceEdit | None:
         """Remap a WorkspaceEdit from child coordinates to original xonsh.
 
+        Edits targeting any document this proxy synced (every open xonsh doc,
+        not just the current one) are in that document's preprocessed +
+        preamble-shifted coordinates and are remapped with its own sync state.
+        Edits to files the child read from disk pass through unchanged.
+
         Only `changes` and `TextDocumentEdit` entries in `document_changes` are
         kept. File-level operations (create/rename/delete file) are dropped.
+
+        Fails closed: if any edit to a synced document cannot be mapped back
+        (masked line, preamble region), the whole rename is refused — applying
+        a partial rename would silently corrupt code.
         """
-        preamble = self._preamble_offset(current_uri)
 
         def remap_edits(
             child_uri: str, edits: Sequence[lsp.TextEdit]
-        ) -> tuple[str, list[lsp.TextEdit]]:
+        ) -> tuple[str, list[lsp.TextEdit]] | None:
             original_uri = self._uri_map.get(child_uri, child_uri)
-            is_current = child_uri == current_uri
+            state = self._sync_state.get(child_uri)
             remapped: list[lsp.TextEdit] = []
             for e in edits:
                 text_edit = remap_text_edit(
-                    current_pp,
+                    state.preprocess_result if state else None,
                     e.range.start.line,
                     e.range.start.character,
                     e.range.end.line,
                     e.range.end.character,
                     e.new_text,
-                    is_current=is_current,
-                    preamble_offset=preamble,
+                    is_current=state is not None,
+                    preamble_offset=state.preamble_lines if state else 0,
                 )
-                if text_edit is not None:
-                    remapped.append(text_edit)
+                if text_edit is None:
+                    logger.debug(
+                        f"Unmappable rename edit in {child_uri}; refusing rename"
+                    )
+                    return None
+                remapped.append(text_edit)
             return original_uri, remapped
 
         changes: dict[str, list[lsp.TextEdit]] = {}
 
         if edit.changes:
             for child_uri, edits in edit.changes.items():
-                target_uri, remapped = remap_edits(child_uri, edits)
+                result = remap_edits(child_uri, edits)
+                if result is None:
+                    return None
+                target_uri, remapped = result
                 if remapped:
                     changes.setdefault(target_uri, []).extend(remapped)
 
@@ -715,7 +728,10 @@ class LspProxyBackend:
                 text_edits = [
                     te for te in doc_change.edits if isinstance(te, lsp.TextEdit)
                 ]
-                target_uri, remapped = remap_edits(child_uri, text_edits)
+                result = remap_edits(child_uri, text_edits)
+                if result is None:
+                    return None
+                target_uri, remapped = result
                 if remapped:
                     changes.setdefault(target_uri, []).extend(remapped)
 

--- a/src/xonsh_lsp/python_backend.py
+++ b/src/xonsh_lsp/python_backend.py
@@ -98,6 +98,29 @@ class PythonBackend(Protocol):
         """
         ...
 
+    async def rename(
+        self,
+        source: str,
+        line: int,
+        col: int,
+        new_name: str,
+        path: str | None = None,
+    ) -> lsp.WorkspaceEdit | None:
+        """Rename the symbol at the given position.
+
+        Args:
+            source: The original xonsh source code.
+            line: 0-based line number.
+            col: 0-based column number.
+            new_name: The new name for the symbol.
+            path: Optional file path for context.
+
+        Returns:
+            Workspace edit applying the rename, or None if the symbol
+            cannot be renamed.
+        """
+        ...
+
     async def get_diagnostics(
         self, source: str, path: str | None = None
     ) -> list[lsp.Diagnostic]:

--- a/src/xonsh_lsp/python_backend_common.py
+++ b/src/xonsh_lsp/python_backend_common.py
@@ -1,0 +1,49 @@
+from lsprotocol import types as lsp
+
+from xonsh_lsp.preprocessing import PreprocessResult, map_position_from_processed
+
+
+def remap_text_edit(
+    pp: PreprocessResult,
+    start_line: int,
+    start_col: int,
+    end_line: int,
+    end_col: int,
+    new_text: str,
+    *,
+    is_current: bool,
+    preamble_offset: int = 0,
+) -> lsp.TextEdit | None:
+    """Build a TextEdit in original xonsh coordinates.
+
+    When ``is_current`` is True, the input range is interpreted in
+    processed-source coordinates and mapped back to the original xonsh
+    source. Edits falling above the preamble or starting on a masked
+    (xonsh-only) line are dropped (returns None).
+
+    When ``is_current`` is False (edit targets a different file), the
+    coordinates are used as-is.
+    """
+    if is_current:
+        start_line -= preamble_offset
+        end_line -= preamble_offset
+        if start_line < 0:
+            return None
+        orig_start_line, orig_start_col = map_position_from_processed(
+            pp, start_line, start_col
+        )
+        orig_end_line, orig_end_col = map_position_from_processed(
+            pp, end_line, end_col
+        )
+        if orig_start_line in pp.masked_lines:
+            return None
+        start_line, start_col = orig_start_line, orig_start_col
+        end_line, end_col = orig_end_line, orig_end_col
+
+    return lsp.TextEdit(
+        range=lsp.Range(
+            start=lsp.Position(line=start_line, character=start_col),
+            end=lsp.Position(line=end_line, character=end_col),
+        ),
+        new_text=new_text,
+    )

--- a/src/xonsh_lsp/python_backend_common.py
+++ b/src/xonsh_lsp/python_backend_common.py
@@ -4,7 +4,7 @@ from xonsh_lsp.preprocessing import PreprocessResult, map_position_from_processe
 
 
 def remap_text_edit(
-    pp: PreprocessResult,
+    pp: PreprocessResult | None,
     start_line: int,
     start_col: int,
     end_line: int,
@@ -25,6 +25,8 @@ def remap_text_edit(
     coordinates are used as-is.
     """
     if is_current:
+        if pp is None:
+            return None
         start_line -= preamble_offset
         end_line -= preamble_offset
         if start_line < 0:

--- a/src/xonsh_lsp/server.py
+++ b/src/xonsh_lsp/server.py
@@ -482,7 +482,7 @@ async def references(params: lsp.ReferenceParams) -> list[lsp.Location] | None:
 
 @server.feature(lsp.TEXT_DOCUMENT_RENAME, lsp.RenameOptions(prepare_provider=False))
 async def rename(params: lsp.RenameParams) -> lsp.WorkspaceEdit | None:
-    """Rename Python identifiers by delegating to the active backend."""
+    """Rename Python identifiers."""
     uri = params.text_document.uri
     doc = server.get_document(uri)
     if doc is None:

--- a/src/xonsh_lsp/server.py
+++ b/src/xonsh_lsp/server.py
@@ -10,6 +10,7 @@ import argparse
 import keyword
 import logging
 import os
+import re
 from typing import TYPE_CHECKING, Any, NamedTuple
 
 from lsprotocol import types as lsp
@@ -128,48 +129,35 @@ def _is_python_identifier(value: str) -> bool:
     return value.isidentifier() and not keyword.iskeyword(value)
 
 
+_IDENT_RE = re.compile(r"[^\W\d]\w*")
+
+
 def _python_identifier_range_at_position(
     source: str,
     line: int,
     character: int,
 ) -> lsp.Range | None:
     lines = source.splitlines()
-    if line < 0 or line >= len(lines):
+    if not 0 <= line < len(lines):
         return None
-
     line_text = lines[line]
-    if not line_text:
-        return None
 
-    if character < len(line_text) and (
-        line_text[character].isalnum() or line_text[character] == "_"
-    ):
-        index = character
-    elif character > 0 and (line_text[character - 1].isalnum() or line_text[character - 1] == "_"):
-        index = character - 1
-    else:
-        return None
-
-    start = index
-    while start > 0 and (line_text[start - 1].isalnum() or line_text[start - 1] == "_"):
-        start -= 1
-
-    end = index + 1
-    while end < len(line_text) and (line_text[end].isalnum() or line_text[end] == "_"):
-        end += 1
-
-    identifier = line_text[start:end]
-    if not _is_python_identifier(identifier):
-        return None
-    if start > 0 and line_text[start - 1] == "$":
-        return None
-    if start >= 2 and line_text[start - 2:start] == "${":
-        return None
-
-    return lsp.Range(
-        start=lsp.Position(line=line, character=start),
-        end=lsp.Position(line=line, character=end),
-    )
+    for m in _IDENT_RE.finditer(line_text):
+        start, end = m.span()
+        if not start <= character <= end:
+            continue
+        if not _is_python_identifier(m.group()):
+            return None
+        # Reject xonsh env-var prefixes: $FOO and ${FOO}.
+        if start > 0 and line_text[start - 1] == "$":
+            return None
+        if start >= 2 and line_text[start - 2 : start] == "${":
+            return None
+        return lsp.Range(
+            start=lsp.Position(line=line, character=start),
+            end=lsp.Position(line=line, character=end),
+        )
+    return None
 
 
 def _create_backend(

--- a/src/xonsh_lsp/server.py
+++ b/src/xonsh_lsp/server.py
@@ -172,30 +172,6 @@ def _python_identifier_range_at_position(
     )
 
 
-def _range_key(range_: lsp.Range) -> tuple[int, int, int, int]:
-    return (
-        range_.start.line,
-        range_.start.character,
-        range_.end.line,
-        range_.end.character,
-    )
-
-
-def _source_text_for_range(source: str, range_: lsp.Range) -> str | None:
-    if range_.start.line != range_.end.line:
-        return None
-
-    lines = source.splitlines()
-    if range_.start.line < 0 or range_.start.line >= len(lines):
-        return None
-
-    line = lines[range_.start.line]
-    if range_.start.character < 0 or range_.end.character > len(line):
-        return None
-
-    return line[range_.start.character:range_.end.character]
-
-
 def _create_backend(
     backend_name: str,
     backend_command: list[str] | None,
@@ -506,7 +482,7 @@ async def references(params: lsp.ReferenceParams) -> list[lsp.Location] | None:
 
 @server.feature(lsp.TEXT_DOCUMENT_RENAME, lsp.RenameOptions(prepare_provider=False))
 async def rename(params: lsp.RenameParams) -> lsp.WorkspaceEdit | None:
-    """Rename Python identifiers."""
+    """Rename Python identifiers by delegating to the active backend."""
     uri = params.text_document.uri
     doc = server.get_document(uri)
     if doc is None:
@@ -515,6 +491,8 @@ async def rename(params: lsp.RenameParams) -> lsp.WorkspaceEdit | None:
     if not _is_python_identifier(params.new_name):
         return None
 
+    # Reject env vars and other non-Python-identifier targets up front so
+    # backends don't get asked to rename `FOO` inside `$FOO`.
     target_range = _python_identifier_range_at_position(
         doc.source,
         params.position.line,
@@ -523,37 +501,13 @@ async def rename(params: lsp.RenameParams) -> lsp.WorkspaceEdit | None:
     if target_range is None:
         return None
 
-    old_name = _source_text_for_range(doc.source, target_range)
-    if old_name is None:
-        return None
-
-    refs = await server.python_delegate.get_references(
+    return await server.python_delegate.rename(
         doc.source,
         params.position.line,
         params.position.character,
+        params.new_name,
         doc.path,
     )
-
-    edits: list[lsp.TextEdit] = []
-    seen: set[tuple[int, int, int, int]] = set()
-    for ref in refs:
-        if ref.uri != uri:
-            continue
-
-        key = _range_key(ref.range)
-        if key in seen:
-            continue
-
-        if _source_text_for_range(doc.source, ref.range) != old_name:
-            continue
-
-        seen.add(key)
-        edits.append(lsp.TextEdit(range=ref.range, new_text=params.new_name))
-
-    if not edits:
-        return None
-
-    return lsp.WorkspaceEdit(changes={uri: edits})
 
 
 # ============================================================================

--- a/src/xonsh_lsp/server.py
+++ b/src/xonsh_lsp/server.py
@@ -7,6 +7,7 @@ Main LSP server implementation using pygls.
 from __future__ import annotations
 
 import argparse
+import keyword
 import logging
 import os
 from typing import TYPE_CHECKING, Any, NamedTuple
@@ -121,6 +122,78 @@ server = XonshLanguageServer(
     name="xonsh-lsp",
     version=_xonsh_lsp_version,
 )
+
+
+def _is_python_identifier(value: str) -> bool:
+    return value.isidentifier() and not keyword.iskeyword(value)
+
+
+def _python_identifier_range_at_position(
+    source: str,
+    line: int,
+    character: int,
+) -> lsp.Range | None:
+    lines = source.splitlines()
+    if line < 0 or line >= len(lines):
+        return None
+
+    line_text = lines[line]
+    if not line_text:
+        return None
+
+    if character < len(line_text) and (
+        line_text[character].isalnum() or line_text[character] == "_"
+    ):
+        index = character
+    elif character > 0 and (line_text[character - 1].isalnum() or line_text[character - 1] == "_"):
+        index = character - 1
+    else:
+        return None
+
+    start = index
+    while start > 0 and (line_text[start - 1].isalnum() or line_text[start - 1] == "_"):
+        start -= 1
+
+    end = index + 1
+    while end < len(line_text) and (line_text[end].isalnum() or line_text[end] == "_"):
+        end += 1
+
+    identifier = line_text[start:end]
+    if not _is_python_identifier(identifier):
+        return None
+    if start > 0 and line_text[start - 1] == "$":
+        return None
+    if start >= 2 and line_text[start - 2:start] == "${":
+        return None
+
+    return lsp.Range(
+        start=lsp.Position(line=line, character=start),
+        end=lsp.Position(line=line, character=end),
+    )
+
+
+def _range_key(range_: lsp.Range) -> tuple[int, int, int, int]:
+    return (
+        range_.start.line,
+        range_.start.character,
+        range_.end.line,
+        range_.end.character,
+    )
+
+
+def _source_text_for_range(source: str, range_: lsp.Range) -> str | None:
+    if range_.start.line != range_.end.line:
+        return None
+
+    lines = source.splitlines()
+    if range_.start.line < 0 or range_.start.line >= len(lines):
+        return None
+
+    line = lines[range_.start.line]
+    if range_.start.character < 0 or range_.end.character > len(line):
+        return None
+
+    return line[range_.start.character:range_.end.character]
 
 
 def _create_backend(
@@ -424,6 +497,63 @@ async def references(params: lsp.ReferenceParams) -> list[lsp.Location] | None:
             unique_refs.append(ref)
 
     return unique_refs if unique_refs else None
+
+
+# ============================================================================
+# Rename
+# ============================================================================
+
+
+@server.feature(lsp.TEXT_DOCUMENT_RENAME, lsp.RenameOptions(prepare_provider=False))
+async def rename(params: lsp.RenameParams) -> lsp.WorkspaceEdit | None:
+    """Rename Python identifiers."""
+    uri = params.text_document.uri
+    doc = server.get_document(uri)
+    if doc is None:
+        return None
+
+    if not _is_python_identifier(params.new_name):
+        return None
+
+    target_range = _python_identifier_range_at_position(
+        doc.source,
+        params.position.line,
+        params.position.character,
+    )
+    if target_range is None:
+        return None
+
+    old_name = _source_text_for_range(doc.source, target_range)
+    if old_name is None:
+        return None
+
+    refs = await server.python_delegate.get_references(
+        doc.source,
+        params.position.line,
+        params.position.character,
+        doc.path,
+    )
+
+    edits: list[lsp.TextEdit] = []
+    seen: set[tuple[int, int, int, int]] = set()
+    for ref in refs:
+        if ref.uri != uri:
+            continue
+
+        key = _range_key(ref.range)
+        if key in seen:
+            continue
+
+        if _source_text_for_range(doc.source, ref.range) != old_name:
+            continue
+
+        seen.add(key)
+        edits.append(lsp.TextEdit(range=ref.range, new_text=params.new_name))
+
+    if not edits:
+        return None
+
+    return lsp.WorkspaceEdit(changes={uri: edits})
 
 
 # ============================================================================

--- a/src/xonsh_lsp/server.py
+++ b/src/xonsh_lsp/server.py
@@ -160,6 +160,50 @@ def _python_identifier_range_at_position(
     return None
 
 
+def _env_var_edits(
+    parser: XonshParser,
+    parse_result: ParseResult,
+    line: int,
+    character: int,
+    new_name: str,
+) -> list[lsp.TextEdit] | None:
+    """TextEdits renaming the env var under the cursor, current doc only.
+
+    Covers `$FOO`, `${FOO}` and `${'FOO'}` occurrences of the same variable.
+    Returns None when the cursor is not on an env variable.
+    """
+    def contains(node) -> bool:
+        return node.start_point <= (line, character) <= node.end_point
+
+    target = next((n for n in parse_result.env_variables if contains(n)), None)
+    if target is None:
+        return None
+    name = parser.get_env_var_name(target)
+    if not name:
+        return None
+
+    edits: list[lsp.TextEdit] = []
+    for node in parse_result.env_variables:
+        if parser.get_env_var_name(node) != name:
+            continue
+        offset = node.text.find(name)
+        if offset < 0:
+            continue
+        row, col = node.start_point
+        edits.append(
+            lsp.TextEdit(
+                range=lsp.Range(
+                    start=lsp.Position(line=row, character=col + offset),
+                    end=lsp.Position(
+                        line=row, character=col + offset + len(name)
+                    ),
+                ),
+                new_text=new_name,
+            )
+        )
+    return edits or None
+
+
 def _create_backend(
     backend_name: str,
     backend_command: list[str] | None,
@@ -470,7 +514,7 @@ async def references(params: lsp.ReferenceParams) -> list[lsp.Location] | None:
 
 @server.feature(lsp.TEXT_DOCUMENT_RENAME, lsp.RenameOptions(prepare_provider=False))
 async def rename(params: lsp.RenameParams) -> lsp.WorkspaceEdit | None:
-    """Rename Python identifiers."""
+    """Rename Python identifiers and xonsh env variables."""
     uri = params.text_document.uri
     doc = server.get_document(uri)
     if doc is None:
@@ -478,6 +522,19 @@ async def rename(params: lsp.RenameParams) -> lsp.WorkspaceEdit | None:
 
     if not _is_python_identifier(params.new_name):
         return None
+
+    # Env variables are renamed via the xonsh parse tree, current doc only.
+    parse_result = server.parse_document(uri)
+    if parse_result is not None:
+        env_edits = _env_var_edits(
+            server.parser,
+            parse_result,
+            params.position.line,
+            params.position.character,
+            params.new_name,
+        )
+        if env_edits:
+            return lsp.WorkspaceEdit(changes={uri: env_edits})
 
     # Reject env vars and other non-Python-identifier targets up front so
     # backends don't get asked to rename `FOO` inside `$FOO`.

--- a/tests/test_jedi_backend.py
+++ b/tests/test_jedi_backend.py
@@ -1,0 +1,24 @@
+import pytest
+
+
+class TestJediBackend:
+
+    @pytest.mark.asyncio
+    async def test_jedi_rename_produces_expected_edits(self):
+        from xonsh_lsp.jedi_backend import JEDI_AVAILABLE, JediBackend
+
+        if not JEDI_AVAILABLE:
+            pytest.skip("jedi not installed")
+
+        backend = JediBackend()
+        src = "value = 1\nprint(value)\nvalue = value + 1\n"
+        edit = await backend.rename(src, 0, 2, "renamed", path=None)
+
+        assert edit is not None
+        assert edit.changes is not None
+        edits = next(iter(edit.changes.values()))
+        ranges = sorted(
+            (e.range.start.line, e.range.start.character) for e in edits
+        )
+        assert ranges == [(0, 0), (1, 6), (2, 0), (2, 8)]
+        assert all(e.new_text == "renamed" for e in edits)

--- a/tests/test_lsp_proxy_backend.py
+++ b/tests/test_lsp_proxy_backend.py
@@ -1706,3 +1706,86 @@ class TestTokenInReplacement:
         mapping = [(0, 0), (5, 21), (20, 36)]
         # Token from proc 15 to 25 (spans replacement and identity)
         assert _token_in_replacement(mapping, 15, 25) is False
+
+
+class TestRemapWorkspaceEdit:
+    """Tests for _remap_workspace_edit (rename coordinate remapping)."""
+
+    @staticmethod
+    def _edit(line: int, char: int, length: int, text: str = "renamed") -> lsp.TextEdit:
+        return lsp.TextEdit(
+            range=lsp.Range(
+                start=lsp.Position(line=line, character=char),
+                end=lsp.Position(line=line, character=char + length),
+            ),
+            new_text=text,
+        )
+
+    @pytest.fixture
+    def backend(self):
+        from xonsh_lsp.lsp_proxy_backend import _SyncState
+        from xonsh_lsp.preprocessing import preprocess_with_mapping
+
+        backend = LspProxyBackend(["dummy-lsp"])
+        backend._sync_state["file:///a.py"] = _SyncState(
+            preprocess_result=preprocess_with_mapping("value = 1\nprint(value)\n"),
+            preamble_lines=0,
+        )
+        # Second synced xonsh doc, child sees 2 preamble lines on top.
+        backend._sync_state["file:///b.py"] = _SyncState(
+            preprocess_result=preprocess_with_mapping("value = 2\n"),
+            preamble_lines=2,
+        )
+        backend._uri_map["file:///a.py"] = "file:///a.xsh"
+        backend._uri_map["file:///b.py"] = "file:///b.xsh"
+        return backend
+
+    def test_other_synced_doc_remapped_with_own_preamble(self, backend):
+        """Edits in a second synced xonsh doc use that doc's sync state."""
+        edit = lsp.WorkspaceEdit(
+            changes={
+                "file:///a.py": [self._edit(0, 0, 5)],
+                "file:///b.py": [self._edit(2, 0, 5)],  # line 0 + its preamble of 2
+            }
+        )
+        result = backend._remap_workspace_edit(edit)
+        assert result is not None
+        assert set(result.changes) == {"file:///a.xsh", "file:///b.xsh"}
+        b_edit = result.changes["file:///b.xsh"][0]
+        assert b_edit.range.start.line == 0
+        assert b_edit.range.start.character == 0
+
+    def test_unsynced_disk_file_passes_through(self, backend):
+        edit = lsp.WorkspaceEdit(
+            changes={"file:///lib/helper.py": [self._edit(7, 4, 5)]}
+        )
+        result = backend._remap_workspace_edit(edit)
+        assert result is not None
+        e = result.changes["file:///lib/helper.py"][0]
+        assert (e.range.start.line, e.range.start.character) == (7, 4)
+
+    def test_unmappable_edit_refuses_whole_rename(self, backend):
+        """An edit inside a synced doc's preamble fails the entire rename."""
+        edit = lsp.WorkspaceEdit(
+            changes={
+                "file:///a.py": [self._edit(0, 0, 5)],
+                "file:///b.py": [self._edit(0, 0, 5)],  # inside b's preamble
+            }
+        )
+        assert backend._remap_workspace_edit(edit) is None
+
+    def test_document_changes_remapped(self, backend):
+        edit = lsp.WorkspaceEdit(
+            document_changes=[
+                lsp.TextDocumentEdit(
+                    text_document=lsp.OptionalVersionedTextDocumentIdentifier(
+                        uri="file:///b.py", version=None
+                    ),
+                    edits=[self._edit(2, 0, 5)],
+                )
+            ]
+        )
+        result = backend._remap_workspace_edit(edit)
+        assert result is not None
+        e = result.changes["file:///b.xsh"][0]
+        assert e.range.start.line == 0

--- a/tests/test_rename.py
+++ b/tests/test_rename.py
@@ -1,0 +1,142 @@
+"""Tests for rename support."""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from lsprotocol import types as lsp
+
+from xonsh_lsp import server as server_module
+
+
+class TestRename:
+    """Test textDocument/rename support."""
+
+    @pytest.fixture
+    def mock_doc(self):
+        """Create a mock document."""
+        doc = MagicMock()
+        doc.source = "value = 1\nprint(value)\nvalue = value + 1\n"
+        doc.path = "/test/file.xsh"
+        return doc
+
+    @pytest.fixture
+    def patched_server(self, monkeypatch, mock_doc):
+        """Patch the module-level server used by the handler."""
+        mock_server = MagicMock()
+        mock_server.get_document.return_value = mock_doc
+        mock_server.python_delegate.get_references = AsyncMock(
+            return_value=[
+                lsp.Location(
+                    uri="file:///test/file.xsh",
+                    range=lsp.Range(
+                        start=lsp.Position(line=0, character=0),
+                        end=lsp.Position(line=0, character=5),
+                    ),
+                ),
+                lsp.Location(
+                    uri="file:///test/file.xsh",
+                    range=lsp.Range(
+                        start=lsp.Position(line=1, character=6),
+                        end=lsp.Position(line=1, character=11),
+                    ),
+                ),
+                lsp.Location(
+                    uri="file:///test/file.xsh",
+                    range=lsp.Range(
+                        start=lsp.Position(line=2, character=0),
+                        end=lsp.Position(line=2, character=5),
+                    ),
+                ),
+                lsp.Location(
+                    uri="file:///test/file.xsh",
+                    range=lsp.Range(
+                        start=lsp.Position(line=2, character=8),
+                        end=lsp.Position(line=2, character=13),
+                    ),
+                ),
+            ]
+        )
+        monkeypatch.setattr(server_module, "server", mock_server)
+        return mock_server
+
+    @pytest.mark.asyncio
+    async def test_renames_python_identifier(self, patched_server):
+        """Test renaming Python identifier references."""
+        params = lsp.RenameParams(
+            text_document=lsp.TextDocumentIdentifier(uri="file:///test/file.xsh"),
+            position=lsp.Position(line=0, character=2),
+            new_name="renamed",
+        )
+
+        result = await server_module.rename(params)
+
+        assert result is not None
+        assert result.changes is not None
+        edits = result.changes["file:///test/file.xsh"]
+        assert len(edits) == 4
+        assert all(edit.new_text == "renamed" for edit in edits)
+
+    @pytest.mark.asyncio
+    async def test_rejects_invalid_python_identifier(self, patched_server):
+        """Test that invalid Python identifiers are rejected."""
+        params = lsp.RenameParams(
+            text_document=lsp.TextDocumentIdentifier(uri="file:///test/file.xsh"),
+            position=lsp.Position(line=0, character=2),
+            new_name="not-valid",
+        )
+
+        result = await server_module.rename(params)
+
+        assert result is None
+        patched_server.python_delegate.get_references.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_does_not_rename_env_var(self, monkeypatch):
+        """Test that env vars are outside Python identifier rename scope."""
+        doc = MagicMock()
+        doc.source = "$VALUE = 'x'\nprint($VALUE)\n"
+        doc.path = "/test/file.xsh"
+        mock_server = MagicMock()
+        mock_server.get_document.return_value = doc
+        mock_server.python_delegate.get_references = AsyncMock(return_value=[])
+        monkeypatch.setattr(server_module, "server", mock_server)
+
+        params = lsp.RenameParams(
+            text_document=lsp.TextDocumentIdentifier(uri="file:///test/file.xsh"),
+            position=lsp.Position(line=0, character=2),
+            new_name="RENAMED",
+        )
+
+        result = await server_module.rename(params)
+
+        assert result is None
+        mock_server.python_delegate.get_references.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_deduplicates_reference_ranges(self, monkeypatch, mock_doc):
+        """Test that duplicate backend references produce one edit."""
+        range_ = lsp.Range(
+            start=lsp.Position(line=0, character=0),
+            end=lsp.Position(line=0, character=5),
+        )
+        mock_server = MagicMock()
+        mock_server.get_document.return_value = mock_doc
+        mock_server.python_delegate.get_references = AsyncMock(
+            return_value=[
+                lsp.Location(uri="file:///test/file.xsh", range=range_),
+                lsp.Location(uri="file:///test/file.xsh", range=range_),
+            ]
+        )
+        monkeypatch.setattr(server_module, "server", mock_server)
+
+        params = lsp.RenameParams(
+            text_document=lsp.TextDocumentIdentifier(uri="file:///test/file.xsh"),
+            position=lsp.Position(line=0, character=2),
+            new_name="renamed",
+        )
+
+        result = await server_module.rename(params)
+
+        assert result is not None
+        assert result.changes is not None
+        assert len(result.changes["file:///test/file.xsh"]) == 1

--- a/tests/test_rename.py
+++ b/tests/test_rename.py
@@ -8,12 +8,17 @@ from lsprotocol import types as lsp
 from xonsh_lsp import server as server_module
 
 
+def _make_workspace_edit(uri: str, ranges: list[lsp.Range], new_name: str) -> lsp.WorkspaceEdit:
+    return lsp.WorkspaceEdit(
+        changes={uri: [lsp.TextEdit(range=r, new_text=new_name) for r in ranges]}
+    )
+
+
 class TestRename:
     """Test textDocument/rename support."""
 
     @pytest.fixture
     def mock_doc(self):
-        """Create a mock document."""
         doc = MagicMock()
         doc.source = "value = 1\nprint(value)\nvalue = value + 1\n"
         doc.path = "/test/file.xsh"
@@ -21,47 +26,39 @@ class TestRename:
 
     @pytest.fixture
     def patched_server(self, monkeypatch, mock_doc):
-        """Patch the module-level server used by the handler."""
+        """Patch the module-level server with a mock backend.rename."""
+        uri = "file:///test/file.xsh"
+        backend_edit = _make_workspace_edit(
+            uri,
+            [
+                lsp.Range(
+                    start=lsp.Position(line=0, character=0),
+                    end=lsp.Position(line=0, character=5),
+                ),
+                lsp.Range(
+                    start=lsp.Position(line=1, character=6),
+                    end=lsp.Position(line=1, character=11),
+                ),
+                lsp.Range(
+                    start=lsp.Position(line=2, character=0),
+                    end=lsp.Position(line=2, character=5),
+                ),
+                lsp.Range(
+                    start=lsp.Position(line=2, character=8),
+                    end=lsp.Position(line=2, character=13),
+                ),
+            ],
+            new_name="renamed",
+        )
         mock_server = MagicMock()
         mock_server.get_document.return_value = mock_doc
-        mock_server.python_delegate.get_references = AsyncMock(
-            return_value=[
-                lsp.Location(
-                    uri="file:///test/file.xsh",
-                    range=lsp.Range(
-                        start=lsp.Position(line=0, character=0),
-                        end=lsp.Position(line=0, character=5),
-                    ),
-                ),
-                lsp.Location(
-                    uri="file:///test/file.xsh",
-                    range=lsp.Range(
-                        start=lsp.Position(line=1, character=6),
-                        end=lsp.Position(line=1, character=11),
-                    ),
-                ),
-                lsp.Location(
-                    uri="file:///test/file.xsh",
-                    range=lsp.Range(
-                        start=lsp.Position(line=2, character=0),
-                        end=lsp.Position(line=2, character=5),
-                    ),
-                ),
-                lsp.Location(
-                    uri="file:///test/file.xsh",
-                    range=lsp.Range(
-                        start=lsp.Position(line=2, character=8),
-                        end=lsp.Position(line=2, character=13),
-                    ),
-                ),
-            ]
-        )
+        mock_server.python_delegate.rename = AsyncMock(return_value=backend_edit)
         monkeypatch.setattr(server_module, "server", mock_server)
         return mock_server
 
     @pytest.mark.asyncio
-    async def test_renames_python_identifier(self, patched_server):
-        """Test renaming Python identifier references."""
+    async def test_delegates_to_backend(self, patched_server):
+        """Server forwards the rename request to the backend and returns its edit."""
         params = lsp.RenameParams(
             text_document=lsp.TextDocumentIdentifier(uri="file:///test/file.xsh"),
             position=lsp.Position(line=0, character=2),
@@ -75,10 +72,11 @@ class TestRename:
         edits = result.changes["file:///test/file.xsh"]
         assert len(edits) == 4
         assert all(edit.new_text == "renamed" for edit in edits)
+        patched_server.python_delegate.rename.assert_awaited_once()
 
     @pytest.mark.asyncio
     async def test_rejects_invalid_python_identifier(self, patched_server):
-        """Test that invalid Python identifiers are rejected."""
+        """Invalid Python identifiers are rejected before reaching the backend."""
         params = lsp.RenameParams(
             text_document=lsp.TextDocumentIdentifier(uri="file:///test/file.xsh"),
             position=lsp.Position(line=0, character=2),
@@ -88,17 +86,17 @@ class TestRename:
         result = await server_module.rename(params)
 
         assert result is None
-        patched_server.python_delegate.get_references.assert_not_awaited()
+        patched_server.python_delegate.rename.assert_not_awaited()
 
     @pytest.mark.asyncio
     async def test_does_not_rename_env_var(self, monkeypatch):
-        """Test that env vars are outside Python identifier rename scope."""
+        """Env vars are filtered out before the backend is asked."""
         doc = MagicMock()
         doc.source = "$VALUE = 'x'\nprint($VALUE)\n"
         doc.path = "/test/file.xsh"
         mock_server = MagicMock()
         mock_server.get_document.return_value = doc
-        mock_server.python_delegate.get_references = AsyncMock(return_value=[])
+        mock_server.python_delegate.rename = AsyncMock(return_value=None)
         monkeypatch.setattr(server_module, "server", mock_server)
 
         params = lsp.RenameParams(
@@ -110,23 +108,14 @@ class TestRename:
         result = await server_module.rename(params)
 
         assert result is None
-        mock_server.python_delegate.get_references.assert_not_awaited()
+        mock_server.python_delegate.rename.assert_not_awaited()
 
     @pytest.mark.asyncio
-    async def test_deduplicates_reference_ranges(self, monkeypatch, mock_doc):
-        """Test that duplicate backend references produce one edit."""
-        range_ = lsp.Range(
-            start=lsp.Position(line=0, character=0),
-            end=lsp.Position(line=0, character=5),
-        )
+    async def test_returns_none_when_backend_returns_none(self, monkeypatch, mock_doc):
+        """A backend that refuses to rename surfaces as None."""
         mock_server = MagicMock()
         mock_server.get_document.return_value = mock_doc
-        mock_server.python_delegate.get_references = AsyncMock(
-            return_value=[
-                lsp.Location(uri="file:///test/file.xsh", range=range_),
-                lsp.Location(uri="file:///test/file.xsh", range=range_),
-            ]
-        )
+        mock_server.python_delegate.rename = AsyncMock(return_value=None)
         monkeypatch.setattr(server_module, "server", mock_server)
 
         params = lsp.RenameParams(
@@ -137,6 +126,28 @@ class TestRename:
 
         result = await server_module.rename(params)
 
-        assert result is not None
-        assert result.changes is not None
-        assert len(result.changes["file:///test/file.xsh"]) == 1
+        assert result is None
+
+
+class TestJediBackendRename:
+    """End-to-end check that JediBackend produces a real WorkspaceEdit."""
+
+    @pytest.mark.asyncio
+    async def test_jedi_rename_produces_expected_edits(self):
+        from xonsh_lsp.jedi_backend import JEDI_AVAILABLE, JediBackend
+
+        if not JEDI_AVAILABLE:
+            pytest.skip("jedi not installed")
+
+        backend = JediBackend()
+        src = "value = 1\nprint(value)\nvalue = value + 1\n"
+        edit = await backend.rename(src, 0, 2, "renamed", path=None)
+
+        assert edit is not None
+        assert edit.changes is not None
+        edits = next(iter(edit.changes.values()))
+        ranges = sorted(
+            (e.range.start.line, e.range.start.character) for e in edits
+        )
+        assert ranges == [(0, 0), (1, 6), (2, 0), (2, 8)]
+        assert all(e.new_text == "renamed" for e in edits)

--- a/tests/test_server_rename.py
+++ b/tests/test_server_rename.py
@@ -8,13 +8,13 @@ from lsprotocol import types as lsp
 from xonsh_lsp import server as server_module
 
 
-def _make_workspace_edit(uri: str, ranges: list[lsp.Range], new_name: str) -> lsp.WorkspaceEdit:
+def _build_workspace_edit(uri: str, ranges: list[lsp.Range], new_name: str) -> lsp.WorkspaceEdit:
     return lsp.WorkspaceEdit(
         changes={uri: [lsp.TextEdit(range=r, new_text=new_name) for r in ranges]}
     )
 
 
-class TestRename:
+class TestServerRename:
     """Test textDocument/rename support."""
 
     @pytest.fixture
@@ -28,7 +28,7 @@ class TestRename:
     def patched_server(self, monkeypatch, mock_doc):
         """Patch the module-level server with a mock backend.rename."""
         uri = "file:///test/file.xsh"
-        backend_edit = _make_workspace_edit(
+        backend_edit = _build_workspace_edit(
             uri,
             [
                 lsp.Range(
@@ -127,27 +127,3 @@ class TestRename:
         result = await server_module.rename(params)
 
         assert result is None
-
-
-class TestJediBackendRename:
-    """End-to-end check that JediBackend produces a real WorkspaceEdit."""
-
-    @pytest.mark.asyncio
-    async def test_jedi_rename_produces_expected_edits(self):
-        from xonsh_lsp.jedi_backend import JEDI_AVAILABLE, JediBackend
-
-        if not JEDI_AVAILABLE:
-            pytest.skip("jedi not installed")
-
-        backend = JediBackend()
-        src = "value = 1\nprint(value)\nvalue = value + 1\n"
-        edit = await backend.rename(src, 0, 2, "renamed", path=None)
-
-        assert edit is not None
-        assert edit.changes is not None
-        edits = next(iter(edit.changes.values()))
-        ranges = sorted(
-            (e.range.start.line, e.range.start.character) for e in edits
-        )
-        assert ranges == [(0, 0), (1, 6), (2, 0), (2, 8)]
-        assert all(e.new_text == "renamed" for e in edits)

--- a/tests/test_server_rename.py
+++ b/tests/test_server_rename.py
@@ -52,6 +52,10 @@ class TestServerRename:
         )
         mock_server = MagicMock()
         mock_server.get_document.return_value = mock_doc
+        mock_server.parser = server_module.XonshParser()
+        mock_server.parse_document.return_value = mock_server.parser.parse(
+            mock_doc.source
+        )
         mock_server.python_delegate.rename = AsyncMock(return_value=backend_edit)
         monkeypatch.setattr(server_module, "server", mock_server)
         return mock_server
@@ -89,13 +93,15 @@ class TestServerRename:
         patched_server.python_delegate.rename.assert_not_awaited()
 
     @pytest.mark.asyncio
-    async def test_does_not_rename_env_var(self, monkeypatch):
-        """Env vars are filtered out before the backend is asked."""
+    async def test_renames_env_var_without_backend(self, monkeypatch):
+        """Env vars are renamed via the xonsh parse tree, not the backend."""
         doc = MagicMock()
-        doc.source = "$VALUE = 'x'\nprint($VALUE)\n"
+        doc.source = "$VALUE = 'x'\nprint($VALUE)\necho ${VALUE}\n"
         doc.path = "/test/file.xsh"
         mock_server = MagicMock()
         mock_server.get_document.return_value = doc
+        mock_server.parser = server_module.XonshParser()
+        mock_server.parse_document.return_value = mock_server.parser.parse(doc.source)
         mock_server.python_delegate.rename = AsyncMock(return_value=None)
         monkeypatch.setattr(server_module, "server", mock_server)
 
@@ -107,7 +113,14 @@ class TestServerRename:
 
         result = await server_module.rename(params)
 
-        assert result is None
+        assert result is not None
+        edits = result.changes["file:///test/file.xsh"]
+        starts = sorted(
+            (e.range.start.line, e.range.start.character) for e in edits
+        )
+        # Name spans only: after `$` on lines 0-1, after `${` on line 2.
+        assert starts == [(0, 1), (1, 7), (2, 7)]
+        assert all(e.new_text == "RENAMED" for e in edits)
         mock_server.python_delegate.rename.assert_not_awaited()
 
     @pytest.mark.asyncio
@@ -115,6 +128,10 @@ class TestServerRename:
         """A backend that refuses to rename surfaces as None."""
         mock_server = MagicMock()
         mock_server.get_document.return_value = mock_doc
+        mock_server.parser = server_module.XonshParser()
+        mock_server.parse_document.return_value = mock_server.parser.parse(
+            mock_doc.source
+        )
         mock_server.python_delegate.rename = AsyncMock(return_value=None)
         monkeypatch.setattr(server_module, "server", mock_server)
 


### PR DESCRIPTION
Hi, here's the PR we discussed in #5.

I have to apologize for not having reviewed everything; I've been busy with other things and I thought I should rather push the change so you can judge by yourself than wait indefinitely.

I created a module for shared logic between the 2 backend implementations. Claude suggested that there were a number of opportunities for factorization between the 2 modules,  but I only approved it for the new code.

The PR does not cover renaming files.

Tell me what you think :)